### PR TITLE
ci: add Go and frontend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: Go and frontend checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.5'
+          cache-dependency-path: |
+            beamsync/go.sum
+            desktop/go.sum
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: desktop/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: desktop/frontend
+        run: npm ci
+
+      - name: Run frontend lint if configured
+        working-directory: desktop/frontend
+        run: npm run lint --if-present
+
+      - name: Build frontend assets
+        working-directory: desktop/frontend
+        run: npm run build
+
+      - name: Test core Go module
+        working-directory: beamsync
+        run: go test ./...
+
+      - name: Vet core Go module
+        working-directory: beamsync
+        run: go vet ./...
+
+      - name: Build core Go module
+        working-directory: beamsync
+        run: go build ./...
+
+      - name: Test desktop Go module
+        working-directory: desktop
+        run: go test ./...
+
+      - name: Vet desktop Go module
+        working-directory: desktop
+        run: go vet ./...
+
+      - name: Build desktop Go module
+        working-directory: desktop
+        run: go build ./...


### PR DESCRIPTION
## Summary
- add a pull-request CI workflow for BeamSync
- install/build the Svelte frontend before desktop Go checks so embedded `frontend/dist` exists
- run core and desktop Go `test`, `vet`, and `build`; run frontend `npm run lint --if-present` and `npm run build`

Closes #18

## Verification
- /opt/homebrew/bin/npm ci
- /opt/homebrew/bin/npm run lint --if-present
- /opt/homebrew/bin/npm run build
- /opt/homebrew/bin/go test ./... && /opt/homebrew/bin/go vet ./... && /opt/homebrew/bin/go build ./... in `beamsync`
- /opt/homebrew/bin/go test ./... && /opt/homebrew/bin/go vet ./... && /opt/homebrew/bin/go build ./... in `desktop`
- git diff --check

Note: the frontend build currently emits an existing Svelte accessibility warning and npm audit advisories, but the configured commands complete successfully.