### PR TITLE
feat: rate limit transfer endpoints

### DIFF
--- a/beamsync/rate_limiter.go
+++ b/beamsync/rate_limiter.go
@@ -1,0 +1,73 @@
+package beamsync
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type clientRateLimiter struct {
+	mu       sync.Mutex
+	limit    int
+	window   time.Duration
+	requests map[string][]time.Time
+	now      func() time.Time
+}
+
+func newClientRateLimiter(limit int, window time.Duration) *clientRateLimiter {
+	return &clientRateLimiter{
+		limit:    limit,
+		window:   window,
+		requests: make(map[string][]time.Time),
+		now:      time.Now,
+	}
+}
+
+func (l *clientRateLimiter) allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	cutoff := now.Add(-l.window)
+	seen := l.requests[key]
+	keepFrom := 0
+	for keepFrom < len(seen) && seen[keepFrom].Before(cutoff) {
+		keepFrom++
+	}
+	seen = seen[keepFrom:]
+
+	if len(seen) >= l.limit {
+		l.requests[key] = seen
+		return false
+	}
+
+	l.requests[key] = append(seen, now)
+	return true
+}
+
+func clientAddress(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil && host != "" {
+		return host
+	}
+	return r.RemoteAddr
+}
+
+func rateLimitMiddleware(limiter *clientRateLimiter, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		setCORSHeaders(w)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		if !limiter.allow(clientAddress(r)) {
+			w.Header().Set("Retry-After", "60")
+			http.Error(w, "429 Too Many Requests: rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+
+		next(w, r)
+	}
+}

--- a/beamsync/rate_limiter_test.go
+++ b/beamsync/rate_limiter_test.go
@@ -1,0 +1,57 @@
+package beamsync
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientRateLimiterBlocksAfterLimit(t *testing.T) {
+	limiter := newClientRateLimiter(2, time.Minute)
+	now := time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC)
+	limiter.now = func() time.Time { return now }
+
+	if !limiter.allow("192.168.1.10") {
+		t.Fatal("first request should be allowed")
+	}
+	if !limiter.allow("192.168.1.10") {
+		t.Fatal("second request should be allowed")
+	}
+	if limiter.allow("192.168.1.10") {
+		t.Fatal("third request should be blocked")
+	}
+}
+
+func TestClientRateLimiterAllowsAfterWindow(t *testing.T) {
+	limiter := newClientRateLimiter(1, time.Minute)
+	now := time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC)
+	limiter.now = func() time.Time { return now }
+
+	if !limiter.allow("192.168.1.10") {
+		t.Fatal("first request should be allowed")
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	if !limiter.allow("192.168.1.10") {
+		t.Fatal("request after window should be allowed")
+	}
+}
+
+func TestRateLimitMiddlewareReturnsTooManyRequests(t *testing.T) {
+	limiter := newClientRateLimiter(1, time.Minute)
+	handler := rateLimitMiddleware(limiter, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	for i, want := range []int{http.StatusAccepted, http.StatusTooManyRequests} {
+		req := httptest.NewRequest(http.MethodPost, "/upload", nil)
+		req.RemoteAddr = "192.168.1.10:5000"
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+
+		if rec.Code != want {
+			t.Fatalf("request %d status = %d, want %d", i+1, rec.Code, want)
+		}
+	}
+}

--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -464,6 +464,8 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 	}
 
 	mux := http.NewServeMux()
+	transferRequestLimiter := newClientRateLimiter(30, time.Minute)
+	uploadLimiter := newClientRateLimiter(12, time.Minute)
 
 	// ── Heartbeat ────────────────────────────────────────────────────────────
 	mux.HandleFunc("/heartbeat", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
@@ -520,7 +522,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 	})
 
 	// ── Request Transfer (ask before accepting) ──────────────────────────────
-	mux.HandleFunc("/request-transfer", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/request-transfer", rateLimitMiddleware(transferRequestLimiter, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
 		setCORSHeaders(w)
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -636,10 +638,10 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 			emit("transfer_request_timeout", id)
 			http.Error(w, "408 Request Timeout: no response from user", http.StatusRequestTimeout)
 		}
-	}))
+	})))
 
 	// ── Upload ────────────────────────────────────────────────────────────────
-	mux.HandleFunc("/upload", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/upload", rateLimitMiddleware(uploadLimiter, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("📤 POST /upload - Upload started")
 
 		defer func() {
@@ -874,7 +876,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		fmt.Println("✅ Upload handler completed")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("✅ Upload Complete"))
-	}))
+	})))
 
 	portInt, listener, err := FindAvailablePort(startPort, 2, 50)
 	if err != nil {
@@ -939,6 +941,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 	startWatchdog(ctx, state, emit)
 
 	mux := http.NewServeMux()
+	downloadLimiter := newClientRateLimiter(60, time.Minute)
 
 	// ── Heartbeat ─────────────────────────────────────────────────────────────
 	mux.HandleFunc("/heartbeat", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
@@ -1043,7 +1046,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 	if len(filePaths) == 1 {
 		filePath := filePaths[0]
 		filename := filepath.Base(filePath)
-		mux.HandleFunc("/download", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/download", rateLimitMiddleware(downloadLimiter, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
 			setCORSHeaders(w)
 			w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 			w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
@@ -1101,12 +1104,12 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 				StartedAt: startedAt,
 				Error:     errMsg,
 			})
-		}))
+		})))
 	} else {
 		for i, path := range filePaths {
 			idx := i
 			filePath := path
-			mux.HandleFunc(fmt.Sprintf("/download/%d", idx), tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/download/%d", idx), rateLimitMiddleware(downloadLimiter, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
 				setCORSHeaders(w)
 				realName := filepath.Base(filePath)
 				w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
@@ -1165,7 +1168,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 					StartedAt: startedAt,
 					Error:     errMsg,
 				})
-			}))
+			})))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add a small per-client sliding-window rate limiter
- protect transfer request, upload, and download endpoints with endpoint-specific limits
- return HTTP 429 with Retry-After when a client exceeds the window
- add limiter unit coverage

## Tests
- Not run locally: Go tooling is not available on this machine (`go`/`gofmt` not on PATH).

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request rate limiting across transfer, upload, and download endpoints to protect service stability. Clients exceeding configured rate limits receive HTTP 429 responses with retry guidance.

* **Tests**
  * Added comprehensive test coverage for rate limiting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PranavAgarkar07/BeamSync/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->