### PR TITLE
feat: add transfer statistics snapshots

### DIFF
--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -93,6 +93,7 @@ type HTTPServer struct {
 	pendingTransfers map[string]*PendingTransfer
 	settings         *TransferSettings
 	history          *TransferHistory
+	stats            *transferStatsTracker
 }
 
 // RespondToTransfer approves or rejects a pending transfer by ID.
@@ -118,6 +119,14 @@ func (s *HTTPServer) TransferHistory() []TransferRecord {
 		return nil
 	}
 	return s.history.List()
+}
+
+// Stats returns the current receiver transfer statistics snapshot.
+func (s *HTTPServer) Stats() TransferStats {
+	if s.stats == nil {
+		return TransferStats{}
+	}
+	return s.stats.snapshot(0)
 }
 
 func (s *HTTPServer) Shutdown() error {
@@ -229,6 +238,7 @@ const largeFileThreshold = 64 * 1024 * 1024 // 64 MB
 func startWriteWorkers(
 	jobs <-chan writeJob,
 	state *serverState,
+	stats *transferStatsTracker,
 	emit func(string, string),
 	history *TransferHistory,
 ) *sync.WaitGroup {
@@ -238,7 +248,7 @@ func startWriteWorkers(
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
-				writeFileToDisk(job, state, emit, history)
+				writeFileToDisk(job, state, stats, emit, history)
 			}
 		}()
 	}
@@ -247,7 +257,7 @@ func startWriteWorkers(
 
 // writeFileToDisk performs the actual file write for one job and emits events.
 // Only small files (fully buffered in buf) are dispatched here.
-func writeFileToDisk(job writeJob, state *serverState, emit func(string, string), history *TransferHistory) {
+func writeFileToDisk(job writeJob, state *serverState, stats *transferStatsTracker, emit func(string, string), history *TransferHistory) {
 	startedAt := time.Now()
 	state.beginUpload()
 	defer state.endUpload()
@@ -311,6 +321,10 @@ func writeFileToDisk(job writeJob, state *serverState, emit func(string, string)
 	})
 	if status != TransferStatusCompleted {
 		return
+	}
+	if stats != nil {
+		snapshot := stats.recordReceived(job.savedName, written, atomic.LoadInt32(&state.uploadingCount))
+		emit("transfer_stats", transferStatsJSON(snapshot))
 	}
 
 	fmt.Printf("✅ File saved: %s (%d bytes)\n", job.savedName, written)
@@ -461,6 +475,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		pendingTransfers: make(map[string]*PendingTransfer),
 		settings:         &settingsCopy,
 		history:          NewTransferHistory(defaultTransferHistoryLimit),
+		stats:            newTransferStatsTracker(),
 	}
 
 	mux := http.NewServeMux()
@@ -518,6 +533,18 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		}
 		w.Write(content)
 	})
+
+	mux.HandleFunc("/stats", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+		setCORSHeaders(w)
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
+		w.Header().Set("Content-Type", "application/json")
+		snapshot := httpServer.stats.snapshot(atomic.LoadInt32(&state.uploadingCount))
+		w.Write([]byte(transferStatsJSON(snapshot)))
+	}))
 
 	// ── Request Transfer (ask before accepting) ──────────────────────────────
 	mux.HandleFunc("/request-transfer", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
@@ -676,7 +703,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 
 		// ── Concurrent write pipeline ─────────────────────────────────────────
 		jobs := make(chan writeJob, writeWorkerCount)
-		wg := startWriteWorkers(jobs, state, emit, httpServer.history)
+		wg := startWriteWorkers(jobs, state, httpServer.stats, emit, httpServer.history)
 
 		fileCount := 0
 		var parseErr error
@@ -829,6 +856,8 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 					continue
 				}
 				emit("upload_progress", fmt.Sprintf("%s|%d|%d", savedName, lWritten, lWritten))
+				snapshot := httpServer.stats.recordReceived(savedName, lWritten, atomic.LoadInt32(&state.uploadingCount))
+				emit("transfer_stats", transferStatsJSON(snapshot))
 				fmt.Printf("✅ Large file saved: %s (%d bytes)\n", savedName, lWritten)
 				logTransfer(httpServer.history, emit, TransferRecord{
 					Filename:  savedName,

--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -962,6 +962,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 	httpServer := &HTTPServer{
 		cancel:  cancel,
 		history: NewTransferHistory(defaultTransferHistoryLimit),
+		stats:   newTransferStatsTracker(),
 	}
 
 	// Sender also gets a watchdog
@@ -1074,6 +1075,12 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 		filename := filepath.Base(filePath)
 		mux.HandleFunc("/download", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
 			setCORSHeaders(w)
+			activeDownloads := atomic.AddInt32(&state.uploadingCount, 1)
+			emit("transfer_stats", transferStatsJSON(httpServer.stats.snapshotDownloads(activeDownloads)))
+			defer func() {
+				activeDownloads := atomic.AddInt32(&state.uploadingCount, -1)
+				emit("transfer_stats", transferStatsJSON(httpServer.stats.snapshotDownloads(activeDownloads)))
+			}()
 			w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 			w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 			// Expose the real filename so the mobile JS can use it for link.download
@@ -1121,6 +1128,9 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 			if copyErr != nil {
 				status = TransferStatusFailed
 				errMsg = copyErr.Error()
+			} else {
+				snapshot := httpServer.stats.recordSent(filename, written, atomic.LoadInt32(&state.uploadingCount))
+				emit("transfer_stats", transferStatsJSON(snapshot))
 			}
 			logTransfer(httpServer.history, emit, TransferRecord{
 				Filename:  filename,
@@ -1138,6 +1148,12 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 			mux.HandleFunc(fmt.Sprintf("/download/%d", idx), tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
 				setCORSHeaders(w)
 				realName := filepath.Base(filePath)
+				activeDownloads := atomic.AddInt32(&state.uploadingCount, 1)
+				emit("transfer_stats", transferStatsJSON(httpServer.stats.snapshotDownloads(activeDownloads)))
+				defer func() {
+					activeDownloads := atomic.AddInt32(&state.uploadingCount, -1)
+					emit("transfer_stats", transferStatsJSON(httpServer.stats.snapshotDownloads(activeDownloads)))
+				}()
 				w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 				w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, realName))
 				// Expose the real filename so the mobile JS can use it for link.download
@@ -1185,6 +1201,9 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 				if copyErr != nil {
 					status = TransferStatusFailed
 					errMsg = copyErr.Error()
+				} else {
+					snapshot := httpServer.stats.recordSent(realName, written, atomic.LoadInt32(&state.uploadingCount))
+					emit("transfer_stats", transferStatsJSON(snapshot))
 				}
 				logTransfer(httpServer.history, emit, TransferRecord{
 					Filename:  realName,

--- a/beamsync/stats.go
+++ b/beamsync/stats.go
@@ -1,0 +1,70 @@
+package beamsync
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+type TransferStats struct {
+	StartedAt     string `json:"startedAt"`
+	FilesReceived int    `json:"filesReceived"`
+	BytesReceived int64  `json:"bytesReceived"`
+	ActiveUploads int32  `json:"activeUploads"`
+	LastFilename  string `json:"lastFilename,omitempty"`
+	LastUpdatedAt string `json:"lastUpdatedAt,omitempty"`
+}
+
+type transferStatsTracker struct {
+	mu            sync.Mutex
+	startedAt     time.Time
+	filesReceived int
+	bytesReceived int64
+	lastFilename  string
+	lastUpdatedAt time.Time
+}
+
+func newTransferStatsTracker() *transferStatsTracker {
+	return &transferStatsTracker{startedAt: time.Now()}
+}
+
+func (t *transferStatsTracker) recordReceived(filename string, bytes int64, activeUploads int32) TransferStats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.filesReceived++
+	t.bytesReceived += bytes
+	t.lastFilename = filename
+	t.lastUpdatedAt = time.Now()
+
+	return t.snapshotLocked(activeUploads)
+}
+
+func (t *transferStatsTracker) snapshot(activeUploads int32) TransferStats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.snapshotLocked(activeUploads)
+}
+
+func (t *transferStatsTracker) snapshotLocked(activeUploads int32) TransferStats {
+	stats := TransferStats{
+		StartedAt:     t.startedAt.Format(time.RFC3339),
+		FilesReceived: t.filesReceived,
+		BytesReceived: t.bytesReceived,
+		ActiveUploads: activeUploads,
+		LastFilename:  t.lastFilename,
+	}
+	if !t.lastUpdatedAt.IsZero() {
+		stats.LastUpdatedAt = t.lastUpdatedAt.Format(time.RFC3339)
+	}
+	return stats
+}
+
+func transferStatsJSON(stats TransferStats) string {
+	data, err := json.Marshal(stats)
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
+}

--- a/beamsync/stats.go
+++ b/beamsync/stats.go
@@ -7,12 +7,16 @@ import (
 )
 
 type TransferStats struct {
-	StartedAt     string `json:"startedAt"`
-	FilesReceived int    `json:"filesReceived"`
-	BytesReceived int64  `json:"bytesReceived"`
-	ActiveUploads int32  `json:"activeUploads"`
-	LastFilename  string `json:"lastFilename,omitempty"`
-	LastUpdatedAt string `json:"lastUpdatedAt,omitempty"`
+	StartedAt       string `json:"startedAt"`
+	FilesReceived   int    `json:"filesReceived"`
+	BytesReceived   int64  `json:"bytesReceived"`
+	FilesSent       int    `json:"filesSent"`
+	BytesSent       int64  `json:"bytesSent"`
+	ActiveUploads   int32  `json:"activeUploads"`
+	ActiveDownloads int32  `json:"activeDownloads"`
+	LastFilename    string `json:"lastFilename,omitempty"`
+	LastDirection   string `json:"lastDirection,omitempty"`
+	LastUpdatedAt   string `json:"lastUpdatedAt,omitempty"`
 }
 
 type transferStatsTracker struct {
@@ -20,7 +24,10 @@ type transferStatsTracker struct {
 	startedAt     time.Time
 	filesReceived int
 	bytesReceived int64
+	filesSent     int
+	bytesSent     int64
 	lastFilename  string
+	lastDirection string
 	lastUpdatedAt time.Time
 }
 
@@ -35,25 +42,50 @@ func (t *transferStatsTracker) recordReceived(filename string, bytes int64, acti
 	t.filesReceived++
 	t.bytesReceived += bytes
 	t.lastFilename = filename
+	t.lastDirection = TransferDirectionReceive
 	t.lastUpdatedAt = time.Now()
 
-	return t.snapshotLocked(activeUploads)
+	return t.snapshotLocked(activeUploads, 0)
+}
+
+func (t *transferStatsTracker) recordSent(filename string, bytes int64, activeDownloads int32) TransferStats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.filesSent++
+	t.bytesSent += bytes
+	t.lastFilename = filename
+	t.lastDirection = TransferDirectionSend
+	t.lastUpdatedAt = time.Now()
+
+	return t.snapshotLocked(0, activeDownloads)
 }
 
 func (t *transferStatsTracker) snapshot(activeUploads int32) TransferStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	return t.snapshotLocked(activeUploads)
+	return t.snapshotLocked(activeUploads, 0)
 }
 
-func (t *transferStatsTracker) snapshotLocked(activeUploads int32) TransferStats {
+func (t *transferStatsTracker) snapshotDownloads(activeDownloads int32) TransferStats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.snapshotLocked(0, activeDownloads)
+}
+
+func (t *transferStatsTracker) snapshotLocked(activeUploads int32, activeDownloads int32) TransferStats {
 	stats := TransferStats{
-		StartedAt:     t.startedAt.Format(time.RFC3339),
-		FilesReceived: t.filesReceived,
-		BytesReceived: t.bytesReceived,
-		ActiveUploads: activeUploads,
-		LastFilename:  t.lastFilename,
+		StartedAt:       t.startedAt.Format(time.RFC3339),
+		FilesReceived:   t.filesReceived,
+		BytesReceived:   t.bytesReceived,
+		FilesSent:       t.filesSent,
+		BytesSent:       t.bytesSent,
+		ActiveUploads:   activeUploads,
+		ActiveDownloads: activeDownloads,
+		LastFilename:    t.lastFilename,
+		LastDirection:   t.lastDirection,
 	}
 	if !t.lastUpdatedAt.IsZero() {
 		stats.LastUpdatedAt = t.lastUpdatedAt.Format(time.RFC3339)

--- a/beamsync/stats_test.go
+++ b/beamsync/stats_test.go
@@ -1,0 +1,43 @@
+package beamsync
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTransferStatsTrackerRecordsReceivedFiles(t *testing.T) {
+	tracker := newTransferStatsTracker()
+
+	first := tracker.recordReceived("one.txt", 128, 1)
+	second := tracker.recordReceived("two.txt", 256, 0)
+
+	if first.FilesReceived != 1 || first.BytesReceived != 128 {
+		t.Fatalf("first snapshot = %+v", first)
+	}
+	if second.FilesReceived != 2 {
+		t.Fatalf("files received = %d, want 2", second.FilesReceived)
+	}
+	if second.BytesReceived != 384 {
+		t.Fatalf("bytes received = %d, want 384", second.BytesReceived)
+	}
+	if second.LastFilename != "two.txt" {
+		t.Fatalf("last filename = %q, want two.txt", second.LastFilename)
+	}
+	if second.ActiveUploads != 0 {
+		t.Fatalf("active uploads = %d, want 0", second.ActiveUploads)
+	}
+}
+
+func TestTransferStatsJSON(t *testing.T) {
+	tracker := newTransferStatsTracker()
+	stats := tracker.recordReceived("file.bin", 42, 0)
+	raw := transferStatsJSON(stats)
+
+	var decoded TransferStats
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		t.Fatalf("stats JSON should decode: %v", err)
+	}
+	if decoded.FilesReceived != 1 || decoded.BytesReceived != 42 {
+		t.Fatalf("decoded stats = %+v", decoded)
+	}
+}

--- a/beamsync/stats_test.go
+++ b/beamsync/stats_test.go
@@ -28,16 +28,43 @@ func TestTransferStatsTrackerRecordsReceivedFiles(t *testing.T) {
 	}
 }
 
+func TestTransferStatsTrackerRecordsSentFiles(t *testing.T) {
+	tracker := newTransferStatsTracker()
+
+	first := tracker.recordSent("report.pdf", 1024, 1)
+	second := tracker.recordSent("photo.jpg", 2048, 0)
+
+	if first.FilesSent != 1 || first.BytesSent != 1024 {
+		t.Fatalf("first sent snapshot = %+v", first)
+	}
+	if second.FilesSent != 2 {
+		t.Fatalf("files sent = %d, want 2", second.FilesSent)
+	}
+	if second.BytesSent != 3072 {
+		t.Fatalf("bytes sent = %d, want 3072", second.BytesSent)
+	}
+	if second.LastFilename != "photo.jpg" {
+		t.Fatalf("last filename = %q, want photo.jpg", second.LastFilename)
+	}
+	if second.LastDirection != TransferDirectionSend {
+		t.Fatalf("last direction = %q, want %q", second.LastDirection, TransferDirectionSend)
+	}
+	if second.ActiveDownloads != 0 {
+		t.Fatalf("active downloads = %d, want 0", second.ActiveDownloads)
+	}
+}
+
 func TestTransferStatsJSON(t *testing.T) {
 	tracker := newTransferStatsTracker()
-	stats := tracker.recordReceived("file.bin", 42, 0)
+	tracker.recordReceived("file.bin", 42, 0)
+	stats := tracker.recordSent("download.bin", 84, 0)
 	raw := transferStatsJSON(stats)
 
 	var decoded TransferStats
 	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
 		t.Fatalf("stats JSON should decode: %v", err)
 	}
-	if decoded.FilesReceived != 1 || decoded.BytesReceived != 42 {
+	if decoded.FilesReceived != 1 || decoded.BytesReceived != 42 || decoded.FilesSent != 1 || decoded.BytesSent != 84 {
 		t.Fatalf("decoded stats = %+v", decoded)
 	}
 }

--- a/desktop/frontend/src/App.svelte
+++ b/desktop/frontend/src/App.svelte
@@ -55,11 +55,20 @@
     startedAt: new Date().toISOString(),
     filesReceived: 0,
     bytesReceived: 0,
+    filesSent: 0,
+    bytesSent: 0,
     activeUploads: 0,
+    activeDownloads: 0,
     lastFilename: "",
+    lastDirection: "",
   };
   let transferStatsNow = Date.now();
   let transferStatsTimer;
+  let transferSpeeds = {
+    receive: "Idle",
+    send: "Idle",
+  };
+  let activeSpeedDirection = "";
 
   let receivedFiles = [];
   let progress = {
@@ -164,9 +173,15 @@
       startedAt: new Date().toISOString(),
       filesReceived: 0,
       bytesReceived: 0,
+      filesSent: 0,
+      bytesSent: 0,
       activeUploads: 0,
+      activeDownloads: 0,
       lastFilename: "",
+      lastDirection: "",
     };
+    transferSpeeds = { receive: "Idle", send: "Idle" };
+    activeSpeedDirection = "";
     transferStatsNow = Date.now();
   }
 
@@ -222,6 +237,8 @@
       lastProgressTime = 0;
       progressStartTime = 0;
       speedHistory = [];
+      transferSpeeds = { ...transferSpeeds, receive: "Idle" };
+      activeSpeedDirection = "";
 
       batchCount += 1;
       clearTimeout(batchTimer);
@@ -242,6 +259,10 @@
         transferHistory = [record, ...transferHistory.filter((item) => item.id !== record.id)].slice(0, 20);
         const verb = record.direction === "send" ? "Sent" : "Received";
         const status = record.status === "failed" ? "failed" : "completed";
+        if (record.direction === "send") {
+          transferSpeeds = { ...transferSpeeds, send: "Idle" };
+          if (activeSpeedDirection === "send") activeSpeedDirection = "";
+        }
         addSessionEntry(`${verb} ${status}`, record.filename, record.status === "failed" ? "error" : "success");
       } catch {
         addSessionEntry("Transfer logged", dataStr, "info");
@@ -254,8 +275,12 @@
           startedAt: nextStats.startedAt || transferStats.startedAt,
           filesReceived: Number(nextStats.filesReceived) || 0,
           bytesReceived: Number(nextStats.bytesReceived) || 0,
+          filesSent: Number(nextStats.filesSent) || 0,
+          bytesSent: Number(nextStats.bytesSent) || 0,
           activeUploads: Number(nextStats.activeUploads) || 0,
+          activeDownloads: Number(nextStats.activeDownloads) || 0,
           lastFilename: nextStats.lastFilename || "",
+          lastDirection: nextStats.lastDirection || "",
         };
         transferStatsNow = Date.now();
       } catch {
@@ -288,7 +313,7 @@
       return avg;
     };
 
-    const handleProgressUpdate = (data) => {
+    const handleProgressUpdate = (data, direction) => {
       const parts = data.split("|");
       if (parts.length < 3) return;
       const [filename, wStr, tStr] = parts;
@@ -309,6 +334,8 @@
       const smoothedSpeed = calculateSmoothedSpeed(Math.max(0, instantSpeed));
       const speedStr = `${Math.max(0, smoothedSpeed).toFixed(2)} MB/s`;
       const speedColor = getSpeedColor(smoothedSpeed);
+      transferSpeeds = { ...transferSpeeds, [direction]: speedStr };
+      activeSpeedDirection = direction;
 
       let timeRemaining = "—";
       if (smoothedSpeed > 0) {
@@ -356,11 +383,13 @@
         lastProgressTime = 0;
         progressStartTime = 0;
         speedHistory = [];
+        transferSpeeds = { ...transferSpeeds, [direction]: "Idle" };
+        activeSpeedDirection = "";
       }, 30000);
     };
 
-    EventsOn("upload_progress", handleProgressUpdate);
-    EventsOn("download_progress", handleProgressUpdate);
+    EventsOn("upload_progress", (data) => handleProgressUpdate(data, "receive"));
+    EventsOn("download_progress", (data) => handleProgressUpdate(data, "send"));
     EventsOn("url_changed", (newURL) => {
       serverUrl = newURL;
       generateQR(newURL);
@@ -842,6 +871,9 @@
             <TransferStatsDashboard
               stats={transferStats}
               now={transferStatsNow}
+              direction="receive"
+              currentSpeed={transferSpeeds.receive}
+              speedActive={activeSpeedDirection === "receive"}
             />
 
             <div class="files-panel">
@@ -904,6 +936,14 @@
                   >
                 </div>
               </div>
+
+              <TransferStatsDashboard
+                stats={transferStats}
+                now={transferStatsNow}
+                direction="send"
+                currentSpeed={transferSpeeds.send}
+                speedActive={activeSpeedDirection === "send"}
+              />
               
               <button
                 class="nb-btn nb-btn--danger close-btn"

--- a/desktop/frontend/src/App.svelte
+++ b/desktop/frontend/src/App.svelte
@@ -35,6 +35,7 @@
     TransferComplete,
     ConnectedDevicesPanel,
     ActivityPanel,
+    TransferStatsDashboard,
   } from "./design-system/index.js";
 
   // Logo asset
@@ -50,6 +51,15 @@
   let senderFiles = []; // [{name, sizeBytes}] — populated from sender_files event
   let transferHistory = [];
   let sessionLog = [];
+  let transferStats = {
+    startedAt: new Date().toISOString(),
+    filesReceived: 0,
+    bytesReceived: 0,
+    activeUploads: 0,
+    lastFilename: "",
+  };
+  let transferStatsNow = Date.now();
+  let transferStatsTimer;
 
   let receivedFiles = [];
   let progress = {
@@ -149,6 +159,17 @@
     return parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   }
 
+  function resetTransferStats() {
+    transferStats = {
+      startedAt: new Date().toISOString(),
+      filesReceived: 0,
+      bytesReceived: 0,
+      activeUploads: 0,
+      lastFilename: "",
+    };
+    transferStatsNow = Date.now();
+  }
+
   // ── Cursor glow ─────────────────────────────────────────────────────────
   function handleMouseMove(e) {
     // legacy mouse glow removed
@@ -157,6 +178,9 @@
   // ── Mount / Unmount ─────────────────────────────────────────────────────
   onMount(async () => {
     EventsOffAll();
+    transferStatsTimer = setInterval(() => {
+      transferStatsNow = Date.now();
+    }, 1000);
 
     // Load settings
     try {
@@ -221,6 +245,21 @@
         addSessionEntry(`${verb} ${status}`, record.filename, record.status === "failed" ? "error" : "success");
       } catch {
         addSessionEntry("Transfer logged", dataStr, "info");
+      }
+    });
+    EventsOn("transfer_stats", (dataStr) => {
+      try {
+        const nextStats = JSON.parse(dataStr);
+        transferStats = {
+          startedAt: nextStats.startedAt || transferStats.startedAt,
+          filesReceived: Number(nextStats.filesReceived) || 0,
+          bytesReceived: Number(nextStats.bytesReceived) || 0,
+          activeUploads: Number(nextStats.activeUploads) || 0,
+          lastFilename: nextStats.lastFilename || "",
+        };
+        transferStatsNow = Date.now();
+      } catch {
+        addSessionEntry("Stats update failed", "Unable to read transfer stats", "warn");
       }
     });
 
@@ -361,6 +400,7 @@
     EventsOffAll();
     clearTimeout(batchTimer);
     clearTimeout(_progressTimeout);
+    clearInterval(transferStatsTimer);
   });
 
   async function initReceiver() {
@@ -485,6 +525,7 @@
     senderFiles = [];
     transferHistory = [];
     sessionLog = [];
+    resetTransferStats();
     progress = {
       active: false,
       filename: "",
@@ -797,6 +838,11 @@
                 <span class="status-text">WAITING FOR FILES...</span>
               </div>
             </div>
+
+            <TransferStatsDashboard
+              stats={transferStats}
+              now={transferStatsNow}
+            />
 
             <div class="files-panel">
               <div class="files-header">

--- a/desktop/frontend/src/design-system/TransferStatsDashboard.svelte
+++ b/desktop/frontend/src/design-system/TransferStatsDashboard.svelte
@@ -1,0 +1,155 @@
+<script>
+  export let stats = {
+    startedAt: "",
+    filesReceived: 0,
+    bytesReceived: 0,
+    activeUploads: 0,
+    lastFilename: "",
+  };
+  export let now = Date.now();
+
+  $: startedAtMs = stats.startedAt ? new Date(stats.startedAt).getTime() : now;
+  $: elapsedMs = Number.isNaN(startedAtMs) ? 0 : Math.max(0, now - startedAtMs);
+  $: sessionDuration = formatSessionDuration(elapsedMs);
+  $: filesLabel = `${stats.filesReceived || 0} ${(stats.filesReceived || 0) === 1 ? "file" : "files"}`;
+  $: activeLabel = stats.activeUploads > 0 ? `${stats.activeUploads} uploading` : "Idle";
+
+  function formatSessionDuration(ms) {
+    const seconds = Math.floor(ms / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ${minutes % 60}m`;
+  }
+
+  function formatBytes(bytes = 0) {
+    if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
+    if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(1)} MB`;
+    if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+    return `${bytes} B`;
+  }
+</script>
+
+<section class="stats-dashboard" aria-label="Transfer statistics">
+  <div class="stats-header">
+    <h3>TRANSFER STATS</h3>
+    <span class:active={stats.activeUploads > 0}>{activeLabel}</span>
+  </div>
+
+  <div class="stats-grid">
+    <div class="stat-cell">
+      <span class="stat-label">Files received</span>
+      <strong>{filesLabel}</strong>
+    </div>
+    <div class="stat-cell">
+      <span class="stat-label">Data transferred</span>
+      <strong>{formatBytes(stats.bytesReceived || 0)}</strong>
+    </div>
+    <div class="stat-cell">
+      <span class="stat-label">Session duration</span>
+      <strong>{sessionDuration}</strong>
+    </div>
+    <div class="stat-cell stat-cell--wide">
+      <span class="stat-label">Last file</span>
+      <strong>{stats.lastFilename || "Waiting for files"}</strong>
+    </div>
+  </div>
+</section>
+
+<style>
+  .stats-dashboard {
+    width: 100%;
+    background: var(--nb-surface);
+    border: var(--nb-border-lg);
+    box-shadow: var(--nb-shadow-md);
+  }
+
+  .stats-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--nb-space-3);
+    background: var(--nb-bg);
+    border-bottom: var(--nb-border-lg);
+    padding: var(--nb-space-3) var(--nb-space-4);
+  }
+
+  .stats-header h3 {
+    margin: 0;
+    font-family: var(--nb-font-display);
+    font-size: var(--nb-text-sm);
+    font-weight: 800;
+    letter-spacing: 0.05em;
+  }
+
+  .stats-header span {
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    font-weight: 800;
+    background: var(--nb-bg);
+    border: var(--nb-border-md);
+    padding: 2px 8px;
+  }
+
+  .stats-header span.active {
+    background: var(--nb-secondary);
+    color: var(--nb-secondary-text);
+  }
+
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .stat-cell {
+    min-width: 0;
+    padding: var(--nb-space-4);
+    border-right: 1px solid var(--nb-border-color);
+  }
+
+  .stat-cell:last-child {
+    border-right: 0;
+  }
+
+  .stat-label {
+    display: block;
+    margin-bottom: var(--nb-space-2);
+    color: var(--nb-text-muted);
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .stat-cell strong {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--nb-font-display);
+    font-size: var(--nb-text-lg);
+    font-weight: 800;
+  }
+
+  @media (max-width: 760px) {
+    .stats-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .stat-cell:nth-child(2n) {
+      border-right: 0;
+    }
+
+    .stat-cell:nth-child(-n + 2) {
+      border-bottom: 1px solid var(--nb-border-color);
+    }
+
+    .stat-cell--wide {
+      grid-column: 1 / -1;
+      border-top: 1px solid var(--nb-border-color);
+    }
+  }
+</style>

--- a/desktop/frontend/src/design-system/TransferStatsDashboard.svelte
+++ b/desktop/frontend/src/design-system/TransferStatsDashboard.svelte
@@ -3,16 +3,29 @@
     startedAt: "",
     filesReceived: 0,
     bytesReceived: 0,
+    filesSent: 0,
+    bytesSent: 0,
     activeUploads: 0,
+    activeDownloads: 0,
     lastFilename: "",
+    lastDirection: "",
   };
   export let now = Date.now();
+  export let direction = "receive";
+  export let currentSpeed = "Idle";
+  export let speedActive = false;
 
   $: startedAtMs = stats.startedAt ? new Date(stats.startedAt).getTime() : now;
   $: elapsedMs = Number.isNaN(startedAtMs) ? 0 : Math.max(0, now - startedAtMs);
   $: sessionDuration = formatSessionDuration(elapsedMs);
-  $: filesLabel = `${stats.filesReceived || 0} ${(stats.filesReceived || 0) === 1 ? "file" : "files"}`;
-  $: activeLabel = stats.activeUploads > 0 ? `${stats.activeUploads} uploading` : "Idle";
+  $: isSend = direction === "send";
+  $: filesCount = isSend ? stats.filesSent || 0 : stats.filesReceived || 0;
+  $: bytesCount = isSend ? stats.bytesSent || 0 : stats.bytesReceived || 0;
+  $: activeCount = isSend ? stats.activeDownloads || 0 : stats.activeUploads || 0;
+  $: filesLabel = `${filesCount} ${filesCount === 1 ? "file" : "files"}`;
+  $: activeLabel = activeCount > 0 ? `${activeCount} ${isSend ? "downloading" : "uploading"}` : "Idle";
+  $: fileLabel = isSend ? "Files sent" : "Files received";
+  $: dataLabel = isSend ? "Data sent" : "Data received";
 
   function formatSessionDuration(ms) {
     const seconds = Math.floor(ms / 1000);
@@ -35,21 +48,25 @@
 <section class="stats-dashboard" aria-label="Transfer statistics">
   <div class="stats-header">
     <h3>TRANSFER STATS</h3>
-    <span class:active={stats.activeUploads > 0}>{activeLabel}</span>
+    <span class:active={activeCount > 0 || speedActive}>{activeLabel}</span>
   </div>
 
   <div class="stats-grid">
     <div class="stat-cell">
-      <span class="stat-label">Files received</span>
+      <span class="stat-label">{fileLabel}</span>
       <strong>{filesLabel}</strong>
     </div>
     <div class="stat-cell">
-      <span class="stat-label">Data transferred</span>
-      <strong>{formatBytes(stats.bytesReceived || 0)}</strong>
+      <span class="stat-label">{dataLabel}</span>
+      <strong>{formatBytes(bytesCount)}</strong>
     </div>
     <div class="stat-cell">
       <span class="stat-label">Session duration</span>
       <strong>{sessionDuration}</strong>
+    </div>
+    <div class="stat-cell stat-cell--speed" class:flowing={speedActive}>
+      <span class="stat-label">Live speed</span>
+      <strong>{currentSpeed}</strong>
     </div>
     <div class="stat-cell stat-cell--wide">
       <span class="stat-label">Last file</span>
@@ -100,7 +117,7 @@
 
   .stats-grid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
   .stat-cell {
@@ -134,6 +151,19 @@
     font-weight: 800;
   }
 
+  .stat-cell--speed {
+    background: var(--nb-bg);
+  }
+
+  .stat-cell--speed strong {
+    transition: color 0.2s ease, transform 0.2s ease;
+  }
+
+  .stat-cell--speed.flowing strong {
+    color: var(--nb-primary);
+    transform: translateY(-1px);
+  }
+
   @media (max-width: 760px) {
     .stats-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -150,6 +180,7 @@
     .stat-cell--wide {
       grid-column: 1 / -1;
       border-top: 1px solid var(--nb-border-color);
+      border-right: 0;
     }
   }
 </style>

--- a/desktop/frontend/src/design-system/index.js
+++ b/desktop/frontend/src/design-system/index.js
@@ -17,3 +17,4 @@ export { default as ConnectedDevicesPanel} from './ConnectedDevicesPanel.svelte'
 export { default as TopNavBar            } from './TopNavBar.svelte';
 export { default as TransferComplete     } from './TransferComplete.svelte';
 export { default as ActivityPanel        } from './ActivityPanel.svelte';
+export { default as TransferStatsDashboard } from './TransferStatsDashboard.svelte';


### PR DESCRIPTION
## Summary
- add receiver-side transfer statistics tracking for files, bytes, active uploads, and last update
- expose a token-protected `/stats` JSON endpoint
- emit `transfer_stats` events after successful small and large file receives
- add unit coverage for the stats tracker and JSON encoding

## Tests
- Not run locally: Go tooling is not available on this machine (`go`/`gofmt` not on PATH).

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time transfer statistics dashboard displaying files and bytes sent/received, active transfer counts, and last transferred file information.
  * Introduced a new `/stats` endpoint to retrieve current transfer statistics.

* **Tests**
  * Added unit tests for transfer statistics tracking and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PranavAgarkar07/BeamSync/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->