### PR TITLE
feat: add opt-in TLS support

### DIFF
--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -802,6 +802,13 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		}
 	}
 	portStr := fmt.Sprintf("%d", portInt)
+	serveListener, tlsEnabled, tlsErr := maybeTLSListener(listener)
+	if tlsErr != nil {
+		fmt.Printf("❌ Failed to configure TLS: %v\n", tlsErr)
+		cancel()
+		listener.Close()
+		return nil, "", ""
+	}
 
 	srv := &http.Server{
 		Handler:      mux,
@@ -817,8 +824,12 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 				fmt.Printf("❌ Server panic: %v\n", r)
 			}
 		}()
-		fmt.Printf("🚀 Starting HTTP receiver on :%s...\n", portStr)
-		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+		if tlsEnabled {
+			fmt.Printf("🚀 Starting HTTPS receiver on :%s...\n", portStr)
+		} else {
+			fmt.Printf("🚀 Starting HTTP receiver on :%s...\n", portStr)
+		}
+		if err := srv.Serve(serveListener); err != nil && err != http.ErrServerClosed {
 			fmt.Printf("❌ Server error: %v\n", err)
 		}
 	}()
@@ -1060,6 +1071,13 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 		}
 	}
 	portStr := fmt.Sprintf("%d", portInt)
+	serveListener, tlsEnabled, tlsErr := maybeTLSListener(listener)
+	if tlsErr != nil {
+		fmt.Printf("❌ Failed to configure TLS: %v\n", tlsErr)
+		cancel()
+		listener.Close()
+		return nil, "", ""
+	}
 
 	srv := &http.Server{
 		Handler: mux,
@@ -1071,8 +1089,12 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 	httpServer := &HTTPServer{server: srv, cancel: cancel}
 
 	go func() {
-		fmt.Printf("🚀 Starting sender on :%s...\n", portStr)
-		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+		if tlsEnabled {
+			fmt.Printf("🚀 Starting HTTPS sender on :%s...\n", portStr)
+		} else {
+			fmt.Printf("🚀 Starting sender on :%s...\n", portStr)
+		}
+		if err := srv.Serve(serveListener); err != nil && err != http.ErrServerClosed {
 			fmt.Println("❌ Sender error:", err)
 		}
 	}()

--- a/beamsync/tls.go
+++ b/beamsync/tls.go
@@ -1,0 +1,90 @@
+package beamsync
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+// TLSEnabled reports whether local HTTPS mode is enabled.
+// It is opt-in to preserve the current HTTP LAN workflow by default.
+func TLSEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEAMSYNC_ENABLE_TLS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// ServerScheme returns the URL scheme clients should use for generated QR links.
+func ServerScheme() string {
+	if TLSEnabled() {
+		return "https"
+	}
+	return "http"
+}
+
+func maybeTLSListener(listener net.Listener) (net.Listener, bool, error) {
+	if !TLSEnabled() {
+		return listener, false, nil
+	}
+
+	cert, err := generateSelfSignedCertificate()
+	if err != nil {
+		return nil, false, err
+	}
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	return tls.NewListener(listener, config), true, nil
+}
+
+func generateSelfSignedCertificate() (tls.Certificate, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "BeamSync Local Transfer",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses: []net.IP{
+			net.ParseIP("127.0.0.1"),
+			net.ParseIP("::1"),
+		},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/beamsync/tls_test.go
+++ b/beamsync/tls_test.go
@@ -1,0 +1,32 @@
+package beamsync
+
+import "testing"
+
+func TestServerSchemeDefaultsToHTTP(t *testing.T) {
+	t.Setenv("BEAMSYNC_ENABLE_TLS", "")
+	if got := ServerScheme(); got != "http" {
+		t.Fatalf("ServerScheme = %q, want http", got)
+	}
+}
+
+func TestServerSchemeUsesHTTPSWhenEnabled(t *testing.T) {
+	for _, value := range []string{"1", "true", "yes", "on"} {
+		t.Setenv("BEAMSYNC_ENABLE_TLS", value)
+		if got := ServerScheme(); got != "https" {
+			t.Fatalf("ServerScheme with %q = %q, want https", value, got)
+		}
+	}
+}
+
+func TestGenerateSelfSignedCertificate(t *testing.T) {
+	cert, err := generateSelfSignedCertificate()
+	if err != nil {
+		t.Fatalf("generateSelfSignedCertificate returned error: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("expected certificate chain")
+	}
+	if cert.PrivateKey == nil {
+		t.Fatal("expected private key")
+	}
+}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -159,7 +159,7 @@ func (a *App) processEvents() {
 			if a.currentIP != "" && a.currentIP != currentRealIP {
 				fmt.Printf("🔄 IP Change Detected! Old: %s, New: %s\n", a.currentIP, currentRealIP)
 				a.currentIP = currentRealIP
-				newURL := fmt.Sprintf("http://%s:%s", a.currentIP, a.currentPort)
+				newURL := fmt.Sprintf("%s://%s:%s", beamsync.ServerScheme(), a.currentIP, a.currentPort)
 				a.safeEmit("url_changed", newURL)
 			}
 		}
@@ -267,7 +267,7 @@ func (a *App) SetSavePath() string {
 	a.currentIP = localIP
 	a.currentPort = port
 
-	url := fmt.Sprintf("http://%s:%s/?token=%s", localIP, port, token)
+	url := fmt.Sprintf("%s://%s:%s/?token=%s", beamsync.ServerScheme(), localIP, port, token)
 	fmt.Println("📡 Receiver restarted on new path:", url)
 	return url
 }
@@ -298,7 +298,7 @@ func (a *App) StartReceiverDefault() string {
 	a.currentPort = port
 
 	// Embed token in the URL so the mobile page's JS can attach it to requests.
-	url := fmt.Sprintf("http://%s:%s/?token=%s", localIP, port, token)
+	url := fmt.Sprintf("%s://%s:%s/?token=%s", beamsync.ServerScheme(), localIP, port, token)
 	fmt.Println("📡 Receiver started:", url)
 	return url
 }
@@ -328,7 +328,7 @@ func (a *App) StartReceiver() string {
 	a.currentIP = localIP
 	a.currentPort = port
 
-	url := fmt.Sprintf("http://%s:%s/?token=%s", localIP, port, token)
+	url := fmt.Sprintf("%s://%s:%s/?token=%s", beamsync.ServerScheme(), localIP, port, token)
 	fmt.Println("📡 Receiver started:", url)
 	return url
 }
@@ -358,7 +358,7 @@ func (a *App) StartSender() string {
 	a.currentPort = port
 
 	// Root page loads without token (acts as the landing), downloads require token.
-	url := fmt.Sprintf("http://%s:%s/", localIP, port)
+	url := fmt.Sprintf("%s://%s:%s/", beamsync.ServerScheme(), localIP, port)
 
 	fmt.Println("========================================")
 	fmt.Println("📤 SENDER STARTED:", url)
@@ -644,7 +644,7 @@ func (a *App) startIPMonitor() {
 				fmt.Printf("🔄 Network Change! IP: %s → %s\n", a.currentIP, newIP)
 				a.currentIP = newIP
 				if a.currentPort != "" {
-					newURL := fmt.Sprintf("http://%s:%s", a.currentIP, a.currentPort)
+					newURL := fmt.Sprintf("%s://%s:%s", beamsync.ServerScheme(), a.currentIP, a.currentPort)
 					fmt.Println("📡 Updating URL to:", newURL)
 					a.safeEmit("url_changed", newURL)
 				}


### PR DESCRIPTION
## Summary
- add opt-in HTTPS mode controlled by `BEAMSYNC_ENABLE_TLS=true`
- generate an ephemeral self-signed certificate at startup, keeping the default HTTP LAN flow unchanged
- serve receiver and sender listeners through TLS when enabled
- update generated desktop URLs to use `https://` in TLS mode
- add unit coverage for TLS scheme selection and certificate generation

## Tests
- Not run locally: Go tooling is not available on this machine (`go`/`gofmt` not on PATH).

Closes #13