### PR TITLE
feat: add transfer history and session log

### DIFF
--- a/beamsync/history.go
+++ b/beamsync/history.go
@@ -1,0 +1,87 @@
+package beamsync
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const defaultTransferHistoryLimit = 100
+
+const (
+	TransferDirectionReceive = "receive"
+	TransferDirectionSend    = "send"
+
+	TransferStatusCompleted = "completed"
+	TransferStatusFailed    = "failed"
+)
+
+// TransferRecord captures one file transfer attempt for the current app session.
+type TransferRecord struct {
+	ID             string    `json:"id"`
+	Filename       string    `json:"filename"`
+	Direction      string    `json:"direction"`
+	Status         string    `json:"status"`
+	SizeBytes      int64     `json:"sizeBytes"`
+	StartedAt      time.Time `json:"startedAt"`
+	CompletedAt    time.Time `json:"completedAt"`
+	DurationMillis int64     `json:"durationMillis"`
+	Error          string    `json:"error,omitempty"`
+}
+
+// TransferHistory stores the most recent transfer records for one server session.
+type TransferHistory struct {
+	mu         sync.Mutex
+	maxEntries int
+	nextID     uint64
+	entries    []TransferRecord
+}
+
+func NewTransferHistory(maxEntries int) *TransferHistory {
+	if maxEntries <= 0 {
+		maxEntries = defaultTransferHistoryLimit
+	}
+	return &TransferHistory{maxEntries: maxEntries}
+}
+
+func (h *TransferHistory) Add(record TransferRecord) TransferRecord {
+	if h == nil {
+		return record
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.nextID++
+	if record.ID == "" {
+		record.ID = fmt.Sprintf("transfer-%d-%d", time.Now().UnixNano(), h.nextID)
+	}
+	if record.CompletedAt.IsZero() {
+		record.CompletedAt = time.Now()
+	}
+	if record.StartedAt.IsZero() {
+		record.StartedAt = record.CompletedAt
+	}
+	if record.DurationMillis == 0 {
+		record.DurationMillis = record.CompletedAt.Sub(record.StartedAt).Milliseconds()
+	}
+
+	h.entries = append([]TransferRecord{record}, h.entries...)
+	if len(h.entries) > h.maxEntries {
+		h.entries = h.entries[:h.maxEntries]
+	}
+	return record
+}
+
+func (h *TransferHistory) List() []TransferRecord {
+	if h == nil {
+		return nil
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	records := make([]TransferRecord, len(h.entries))
+	copy(records, h.entries)
+	return records
+}

--- a/beamsync/history_test.go
+++ b/beamsync/history_test.go
@@ -1,0 +1,57 @@
+package beamsync
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTransferHistoryStoresNewestFirstAndCapsEntries(t *testing.T) {
+	history := NewTransferHistory(2)
+
+	first := history.Add(TransferRecord{Filename: "one.txt", Direction: TransferDirectionReceive, Status: TransferStatusCompleted})
+	if first.ID == "" {
+		t.Fatal("expected generated record ID")
+	}
+
+	history.Add(TransferRecord{Filename: "two.txt", Direction: TransferDirectionSend, Status: TransferStatusCompleted})
+	history.Add(TransferRecord{Filename: "three.txt", Direction: TransferDirectionReceive, Status: TransferStatusFailed})
+
+	records := history.List()
+	if len(records) != 2 {
+		t.Fatalf("expected capped history length 2, got %d", len(records))
+	}
+	if records[0].Filename != "three.txt" || records[1].Filename != "two.txt" {
+		t.Fatalf("expected newest-first records, got %#v", records)
+	}
+}
+
+func TestTransferHistoryCopiesEntries(t *testing.T) {
+	history := NewTransferHistory(10)
+	history.Add(TransferRecord{Filename: "file.txt", Direction: TransferDirectionReceive, Status: TransferStatusCompleted})
+
+	records := history.List()
+	records[0].Filename = "mutated.txt"
+
+	freshRecords := history.List()
+	if freshRecords[0].Filename != "file.txt" {
+		t.Fatalf("expected history to return a defensive copy, got %q", freshRecords[0].Filename)
+	}
+}
+
+func TestTransferHistoryFillsTimingMetadata(t *testing.T) {
+	history := NewTransferHistory(10)
+	startedAt := time.Now().Add(-2 * time.Second)
+
+	record := history.Add(TransferRecord{
+		Filename:  "timed.txt",
+		StartedAt: startedAt,
+		Status:    TransferStatusCompleted,
+	})
+
+	if record.CompletedAt.IsZero() {
+		t.Fatal("expected completed timestamp")
+	}
+	if record.DurationMillis <= 0 {
+		t.Fatalf("expected positive duration, got %d", record.DurationMillis)
+	}
+}

--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -288,7 +288,9 @@ func writeFileToDisk(job writeJob, state *serverState, emit func(string, string)
 
 	if flushErr := diskBuf.Flush(); flushErr != nil {
 		fmt.Println("❌ Disk flush error:", flushErr)
-		transferErr = flushErr
+		if transferErr == nil {
+			transferErr = flushErr
+		}
 	}
 
 	status := TransferStatusCompleted
@@ -743,6 +745,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 				// racing on the shared bufio.Reader (netReader).
 				fmt.Printf("📦 Large file — writing synchronously: %s\n", savedName)
 				startedAt := time.Now()
+				prefixSize := n
 				state.beginUpload()
 
 				dst, createErr := os.Create(dstPath)
@@ -751,11 +754,15 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 					io.Copy(io.Discard, part) // must drain before NextPart()
 					part.Close()
 					state.endUpload()
+					size := fileSizes[filename]
+					if size == 0 {
+						size = prefixSize
+					}
 					logTransfer(httpServer.history, emit, TransferRecord{
 						Filename:  savedName,
 						Direction: TransferDirectionReceive,
 						Status:    TransferStatusFailed,
-						SizeBytes: fileSizes[filename],
+						SizeBytes: size,
 						StartedAt: startedAt,
 						Error:     createErr.Error(),
 					})

--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -92,6 +92,7 @@ type HTTPServer struct {
 	pendingMu        sync.Mutex
 	pendingTransfers map[string]*PendingTransfer
 	settings         *TransferSettings
+	history          *TransferHistory
 }
 
 // RespondToTransfer approves or rejects a pending transfer by ID.
@@ -110,6 +111,13 @@ func (s *HTTPServer) RespondToTransfer(id string, approved bool) {
 // Settings returns a pointer to the live TransferSettings for in-place updates.
 func (s *HTTPServer) Settings() *TransferSettings {
 	return s.settings
+}
+
+func (s *HTTPServer) TransferHistory() []TransferRecord {
+	if s == nil || s.history == nil {
+		return nil
+	}
+	return s.history.List()
 }
 
 func (s *HTTPServer) Shutdown() error {
@@ -222,6 +230,7 @@ func startWriteWorkers(
 	jobs <-chan writeJob,
 	state *serverState,
 	emit func(string, string),
+	history *TransferHistory,
 ) *sync.WaitGroup {
 	var wg sync.WaitGroup
 	for i := 0; i < writeWorkerCount; i++ {
@@ -229,7 +238,7 @@ func startWriteWorkers(
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
-				writeFileToDisk(job, state, emit)
+				writeFileToDisk(job, state, emit, history)
 			}
 		}()
 	}
@@ -238,13 +247,22 @@ func startWriteWorkers(
 
 // writeFileToDisk performs the actual file write for one job and emits events.
 // Only small files (fully buffered in buf) are dispatched here.
-func writeFileToDisk(job writeJob, state *serverState, emit func(string, string)) {
+func writeFileToDisk(job writeJob, state *serverState, emit func(string, string), history *TransferHistory) {
+	startedAt := time.Now()
 	state.beginUpload()
 	defer state.endUpload()
 
 	dst, err := os.Create(job.dstPath)
 	if err != nil {
 		fmt.Println("❌ File creation error:", err)
+		logTransfer(history, emit, TransferRecord{
+			Filename:  job.savedName,
+			Direction: TransferDirectionReceive,
+			Status:    TransferStatusFailed,
+			SizeBytes: job.totalSize,
+			StartedAt: startedAt,
+			Error:     err.Error(),
+		})
 		return
 	}
 	defer dst.Close()
@@ -262,17 +280,38 @@ func writeFileToDisk(job writeJob, state *serverState, emit func(string, string)
 	}
 	n, werr := pw.Write(job.buf)
 	written := int64(n)
+	var transferErr error
 	if werr != nil {
 		fmt.Println("❌ Write error:", werr)
+		transferErr = werr
 	}
 
 	if flushErr := diskBuf.Flush(); flushErr != nil {
 		fmt.Println("❌ Disk flush error:", flushErr)
+		transferErr = flushErr
+	}
+
+	status := TransferStatusCompleted
+	errMsg := ""
+	if transferErr != nil {
+		status = TransferStatusFailed
+		errMsg = transferErr.Error()
 	}
 
 	emit("upload_progress", fmt.Sprintf("%s|%d|%d", job.savedName, written, written))
-	fmt.Printf("✅ File saved: %s (%d bytes)\n", job.savedName, written)
+	logTransfer(history, emit, TransferRecord{
+		Filename:  job.savedName,
+		Direction: TransferDirectionReceive,
+		Status:    status,
+		SizeBytes: written,
+		StartedAt: startedAt,
+		Error:     errMsg,
+	})
+	if status != TransferStatusCompleted {
+		return
+	}
 
+	fmt.Printf("✅ File saved: %s (%d bytes)\n", job.savedName, written)
 	go func(fname string) {
 		time.Sleep(100 * time.Millisecond)
 		emit("file_received", fname)
@@ -375,6 +414,20 @@ func safeEmit(emit EventCallback, event, data string) {
 	}(event, data)
 }
 
+func logTransfer(history *TransferHistory, emit func(string, string), record TransferRecord) {
+	if history == nil {
+		return
+	}
+
+	saved := history.Add(record)
+	data, err := json.Marshal(saved)
+	if err != nil {
+		fmt.Println("⚠️ Failed to marshal transfer history record:", err)
+		return
+	}
+	emit("transfer_logged", string(data))
+}
+
 // StartServer starts the file-receiver HTTP server.
 // Returns (server handle, port string, session token).
 func StartServer(uploadDir string, startPort int, settings TransferSettings, callback EventCallback) (*HTTPServer, string, string) {
@@ -405,6 +458,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		cancel:           cancel,
 		pendingTransfers: make(map[string]*PendingTransfer),
 		settings:         &settingsCopy,
+		history:          NewTransferHistory(defaultTransferHistoryLimit),
 	}
 
 	mux := http.NewServeMux()
@@ -620,7 +674,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 
 		// ── Concurrent write pipeline ─────────────────────────────────────────
 		jobs := make(chan writeJob, writeWorkerCount)
-		wg := startWriteWorkers(jobs, state, emit)
+		wg := startWriteWorkers(jobs, state, emit, httpServer.history)
 
 		fileCount := 0
 		var parseErr error
@@ -688,6 +742,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 				// Large file — write synchronously on main goroutine to avoid
 				// racing on the shared bufio.Reader (netReader).
 				fmt.Printf("📦 Large file — writing synchronously: %s\n", savedName)
+				startedAt := time.Now()
 				state.beginUpload()
 
 				dst, createErr := os.Create(dstPath)
@@ -696,6 +751,14 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 					io.Copy(io.Discard, part) // must drain before NextPart()
 					part.Close()
 					state.endUpload()
+					logTransfer(httpServer.history, emit, TransferRecord{
+						Filename:  savedName,
+						Direction: TransferDirectionReceive,
+						Status:    TransferStatusFailed,
+						SizeBytes: fileSizes[filename],
+						StartedAt: startedAt,
+						Error:     createErr.Error(),
+					})
 					continue
 				}
 
@@ -727,21 +790,46 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 				}
 				// Write the already-buffered prefix first.
 				prefixBytes := buf.Bytes()
-				lpw.Write(prefixBytes)
+				prefixWritten, prefixErr := lpw.Write(prefixBytes)
 				// Stream the remainder from the network.
 				lWritten, lErr := copyChunked(lpw, part, 8*1024*1024)
-				lWritten += int64(len(prefixBytes))
-				diskBuf.Flush()
+				lWritten += int64(prefixWritten)
+				flushErr := diskBuf.Flush()
 				dst.Close()
 				part.Close()
 				state.endUpload()
 
-				if lErr != nil {
-					fmt.Println("❌ Large file copy error:", lErr)
+				var transferErr error
+				switch {
+				case prefixErr != nil:
+					transferErr = prefixErr
+				case lErr != nil:
+					transferErr = lErr
+				case flushErr != nil:
+					transferErr = flushErr
+				}
+
+				if transferErr != nil {
+					fmt.Println("❌ Large file copy error:", transferErr)
+					logTransfer(httpServer.history, emit, TransferRecord{
+						Filename:  savedName,
+						Direction: TransferDirectionReceive,
+						Status:    TransferStatusFailed,
+						SizeBytes: lWritten,
+						StartedAt: startedAt,
+						Error:     transferErr.Error(),
+					})
 					continue
 				}
 				emit("upload_progress", fmt.Sprintf("%s|%d|%d", savedName, lWritten, lWritten))
 				fmt.Printf("✅ Large file saved: %s (%d bytes)\n", savedName, lWritten)
+				logTransfer(httpServer.history, emit, TransferRecord{
+					Filename:  savedName,
+					Direction: TransferDirectionReceive,
+					Status:    TransferStatusCompleted,
+					SizeBytes: lWritten,
+					StartedAt: startedAt,
+				})
 				go func(fname string) {
 					time.Sleep(100 * time.Millisecond)
 					emit("file_received", fname)
@@ -835,6 +923,10 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 
 	state := &serverState{}
 	ctx, cancel := context.WithCancel(context.Background())
+	httpServer := &HTTPServer{
+		cancel:  cancel,
+		history: NewTransferHistory(defaultTransferHistoryLimit),
+	}
 
 	// Sender also gets a watchdog
 	startWatchdog(ctx, state, emit)
@@ -975,6 +1067,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 			}
 			w.Header().Set("Content-Type", mimeType)
 
+			startedAt := time.Now()
 			// 8 MB read buffer — avoids many small read syscalls when streaming large files.
 			bufReader := bufio.NewReaderSize(file, 8*1024*1024)
 			progressWriter := &downloadProgressWriter{
@@ -986,7 +1079,21 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 				lastEmit:    time.Now(),
 				minInterval: 500 * time.Millisecond,
 			}
-			copyChunked(progressWriter, bufReader, 8*1024*1024)
+			written, copyErr := copyChunked(progressWriter, bufReader, 8*1024*1024)
+			status := TransferStatusCompleted
+			errMsg := ""
+			if copyErr != nil {
+				status = TransferStatusFailed
+				errMsg = copyErr.Error()
+			}
+			logTransfer(httpServer.history, emit, TransferRecord{
+				Filename:  filename,
+				Direction: TransferDirectionSend,
+				Status:    status,
+				SizeBytes: written,
+				StartedAt: startedAt,
+				Error:     errMsg,
+			})
 		}))
 	} else {
 		for i, path := range filePaths {
@@ -1024,6 +1131,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 				}
 				w.Header().Set("Content-Type", mimeType)
 
+				startedAt := time.Now()
 				// 8 MB read buffer — avoids many small read syscalls when streaming large files.
 				bufReader := bufio.NewReaderSize(file, 8*1024*1024)
 				progressWriter := &downloadProgressWriter{
@@ -1035,7 +1143,21 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 					lastEmit:    time.Now(),
 					minInterval: 500 * time.Millisecond,
 				}
-				copyChunked(progressWriter, bufReader, 8*1024*1024)
+				written, copyErr := copyChunked(progressWriter, bufReader, 8*1024*1024)
+				status := TransferStatusCompleted
+				errMsg := ""
+				if copyErr != nil {
+					status = TransferStatusFailed
+					errMsg = copyErr.Error()
+				}
+				logTransfer(httpServer.history, emit, TransferRecord{
+					Filename:  realName,
+					Direction: TransferDirectionSend,
+					Status:    status,
+					SizeBytes: written,
+					StartedAt: startedAt,
+					Error:     errMsg,
+				})
 			}))
 		}
 	}
@@ -1068,7 +1190,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 		WriteTimeout: 4 * time.Hour,
 		IdleTimeout:  60 * time.Second,
 	}
-	httpServer := &HTTPServer{server: srv, cancel: cancel}
+	httpServer.server = srv
 
 	go func() {
 		fmt.Printf("🚀 Starting sender on :%s...\n", portStr)

--- a/desktop/frontend/src/App.svelte
+++ b/desktop/frontend/src/App.svelte
@@ -47,6 +47,8 @@
   let serverUrl = "";
   let senderUrl = "";
   let senderFiles = []; // [{name, sizeBytes}] — populated from sender_files event
+  let transferHistory = [];
+  let sessionLog = [];
 
   let receivedFiles = [];
   let progress = {
@@ -118,6 +120,34 @@
     }, 3200);
   }
 
+  function addSessionEntry(title, detail = "", type = "info") {
+    const now = new Date();
+    sessionLog = [
+      {
+        id: `${now.getTime()}-${sessionLog.length}`,
+        title,
+        detail,
+        type,
+        time: now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+      },
+      ...sessionLog,
+    ].slice(0, 12);
+  }
+
+  function formatDuration(ms = 0) {
+    if (!ms || ms < 1000) return "<1s";
+    const seconds = Math.round(ms / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  }
+
+  function formatTransferTime(value) {
+    if (!value) return "Now";
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return "Now";
+    return parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+
   // ── Cursor glow ─────────────────────────────────────────────────────────
   function handleMouseMove(e) {
     // legacy mouse glow removed
@@ -135,16 +165,19 @@
     EventsOn("device_connected", () => {
       connectionState = "CONNECTED";
       playSound("connect");
+      addSessionEntry("Device connected", "Ready for local transfer", "success");
       toast("⚡ Device linked to network", "success");
     });
     EventsOn("device_disconnected", () => {
       connectionState = "DISCONNECTED";
       playSound("click");
+      addSessionEntry("Device disconnected", "Session link was lost", "warn");
       toast("💔 Signal lost — device disconnected", "warn");
     });
     EventsOn("transfer_request", (dataStr) => {
       playSound("connect");
       transferRequest = JSON.parse(dataStr);
+      addSessionEntry("Transfer request", transferRequest.filename, "info");
     });
     EventsOn("file_received", (filename) => {
       refreshFileList();
@@ -177,6 +210,17 @@
       }, 2500);
 
       toast(`✅ Received: ${filename}`, "success");
+    });
+    EventsOn("transfer_logged", (dataStr) => {
+      try {
+        const record = JSON.parse(dataStr);
+        transferHistory = [record, ...transferHistory.filter((item) => item.id !== record.id)].slice(0, 20);
+        const verb = record.direction === "send" ? "Sent" : "Received";
+        const status = record.status === "failed" ? "failed" : "completed";
+        addSessionEntry(`${verb} ${status}`, record.filename, record.status === "failed" ? "error" : "success");
+      } catch {
+        addSessionEntry("Transfer logged", dataStr, "info");
+      }
     });
 
     const formatTime = (seconds) => {
@@ -438,6 +482,8 @@
     senderUrl = "";
     showSenderDialog = false;
     senderFiles = [];
+    transferHistory = [];
+    sessionLog = [];
     progress = {
       active: false,
       filename: "",
@@ -775,6 +821,48 @@
                 {/each}
               </div>
             </div>
+
+            <div class="activity-panel">
+              <div class="activity-column">
+                <div class="activity-header">
+                  <h3>TRANSFER HISTORY</h3>
+                  <span>{transferHistory.length}</span>
+                </div>
+                <div class="activity-list" class:empty={transferHistory.length === 0}>
+                  {#if transferHistory.length === 0}
+                    <p>No transfers recorded in this session</p>
+                  {/if}
+                  {#each transferHistory as item (item.id)}
+                    <div class="activity-item activity-item--{item.status}">
+                      <span class="activity-item__name">{item.filename}</span>
+                      <span class="activity-item__meta">
+                        {item.direction === "send" ? "SENT" : "RECEIVED"} · {formatSize(item.sizeBytes)} · {formatDuration(item.durationMillis)}
+                      </span>
+                      <span class="activity-item__time">{formatTransferTime(item.completedAt)}</span>
+                    </div>
+                  {/each}
+                </div>
+              </div>
+
+              <div class="activity-column">
+                <div class="activity-header">
+                  <h3>SESSION LOG</h3>
+                  <span>{sessionLog.length}</span>
+                </div>
+                <div class="activity-list" class:empty={sessionLog.length === 0}>
+                  {#if sessionLog.length === 0}
+                    <p>Session events will appear here</p>
+                  {/if}
+                  {#each sessionLog as item (item.id)}
+                    <div class="session-item session-item--{item.type}">
+                      <span class="session-item__title">{item.title}</span>
+                      <span class="session-item__detail">{item.detail}</span>
+                      <span class="session-item__time">{item.time}</span>
+                    </div>
+                  {/each}
+                </div>
+              </div>
+            </div>
           </div>
         {/if}
         </div>
@@ -816,6 +904,48 @@
               >
             </div>
           {/if}
+
+          <div class="activity-panel">
+            <div class="activity-column">
+              <div class="activity-header">
+                <h3>TRANSFER HISTORY</h3>
+                <span>{transferHistory.length}</span>
+              </div>
+              <div class="activity-list" class:empty={transferHistory.length === 0}>
+                {#if transferHistory.length === 0}
+                  <p>No transfers recorded in this session</p>
+                {/if}
+                {#each transferHistory as item (item.id)}
+                  <div class="activity-item activity-item--{item.status}">
+                    <span class="activity-item__name">{item.filename}</span>
+                    <span class="activity-item__meta">
+                      {item.direction === "send" ? "SENT" : "RECEIVED"} · {formatSize(item.sizeBytes)} · {formatDuration(item.durationMillis)}
+                    </span>
+                    <span class="activity-item__time">{formatTransferTime(item.completedAt)}</span>
+                  </div>
+                {/each}
+              </div>
+            </div>
+
+            <div class="activity-column">
+              <div class="activity-header">
+                <h3>SESSION LOG</h3>
+                <span>{sessionLog.length}</span>
+              </div>
+              <div class="activity-list" class:empty={sessionLog.length === 0}>
+                {#if sessionLog.length === 0}
+                  <p>Session events will appear here</p>
+                {/if}
+                {#each sessionLog as item (item.id)}
+                  <div class="session-item session-item--{item.type}">
+                    <span class="session-item__title">{item.title}</span>
+                    <span class="session-item__detail">{item.detail}</span>
+                    <span class="session-item__time">{item.time}</span>
+                  </div>
+                {/each}
+              </div>
+            </div>
+          </div>
         </div>
       {:else if mode === "SETTINGS"}
         <div class="mode-wrapper" in:fly={{ y: 15, duration: 250 }}>
@@ -1460,6 +1590,118 @@
     font-family: var(--nb-font-mono);
     font-size: var(--nb-text-xs);
     color: var(--nb-text-muted);
+  }
+
+  .activity-panel {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--nb-space-4);
+    width: 100%;
+  }
+
+  .activity-column {
+    background: var(--nb-surface);
+    border: var(--nb-border-lg);
+    box-shadow: var(--nb-shadow-md);
+    min-width: 0;
+  }
+
+  .activity-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--nb-space-3);
+    background: var(--nb-bg);
+    border-bottom: var(--nb-border-lg);
+    padding: var(--nb-space-3) var(--nb-space-4);
+  }
+
+  .activity-header h3 {
+    margin: 0;
+    font-family: var(--nb-font-display);
+    font-size: var(--nb-text-sm);
+    font-weight: 800;
+    letter-spacing: 0.05em;
+  }
+
+  .activity-header span {
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    font-weight: 800;
+    background: var(--nb-secondary);
+    color: var(--nb-secondary-text);
+    border: var(--nb-border-md);
+    padding: 2px 8px;
+  }
+
+  .activity-list {
+    max-height: 220px;
+    overflow-y: auto;
+  }
+
+  .activity-list.empty {
+    padding: var(--nb-space-4);
+  }
+
+  .activity-list.empty p {
+    margin: 0;
+    color: var(--nb-text-muted);
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    font-weight: 700;
+    text-align: center;
+  }
+
+  .activity-item,
+  .session-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 4px var(--nb-space-3);
+    padding: var(--nb-space-3) var(--nb-space-4);
+    border-bottom: 1px solid var(--nb-border-color);
+    min-width: 0;
+  }
+
+  .activity-item--failed,
+  .session-item--error {
+    background: rgba(255, 107, 107, 0.12);
+  }
+
+  .session-item--warn {
+    background: rgba(255, 176, 0, 0.12);
+  }
+
+  .activity-item__name,
+  .session-item__title {
+    font-weight: 800;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .activity-item__meta,
+  .session-item__detail {
+    grid-column: 1 / -1;
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    color: var(--nb-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .activity-item__time,
+  .session-item__time {
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    font-weight: 800;
+    color: var(--nb-text-muted);
+  }
+
+  @media (max-width: 760px) {
+    .activity-panel {
+      grid-template-columns: 1fr;
+    }
   }
 
   /* Sender Dialog */

--- a/desktop/frontend/src/App.svelte
+++ b/desktop/frontend/src/App.svelte
@@ -34,6 +34,7 @@
     TransferProgressBar,
     TransferComplete,
     ConnectedDevicesPanel,
+    ActivityPanel,
   } from "./design-system/index.js";
 
   // Logo asset
@@ -822,47 +823,7 @@
               </div>
             </div>
 
-            <div class="activity-panel">
-              <div class="activity-column">
-                <div class="activity-header">
-                  <h3>TRANSFER HISTORY</h3>
-                  <span>{transferHistory.length}</span>
-                </div>
-                <div class="activity-list" class:empty={transferHistory.length === 0}>
-                  {#if transferHistory.length === 0}
-                    <p>No transfers recorded in this session</p>
-                  {/if}
-                  {#each transferHistory as item (item.id)}
-                    <div class="activity-item activity-item--{item.status}">
-                      <span class="activity-item__name">{item.filename}</span>
-                      <span class="activity-item__meta">
-                        {item.direction === "send" ? "SENT" : "RECEIVED"} · {formatSize(item.sizeBytes)} · {formatDuration(item.durationMillis)}
-                      </span>
-                      <span class="activity-item__time">{formatTransferTime(item.completedAt)}</span>
-                    </div>
-                  {/each}
-                </div>
-              </div>
-
-              <div class="activity-column">
-                <div class="activity-header">
-                  <h3>SESSION LOG</h3>
-                  <span>{sessionLog.length}</span>
-                </div>
-                <div class="activity-list" class:empty={sessionLog.length === 0}>
-                  {#if sessionLog.length === 0}
-                    <p>Session events will appear here</p>
-                  {/if}
-                  {#each sessionLog as item (item.id)}
-                    <div class="session-item session-item--{item.type}">
-                      <span class="session-item__title">{item.title}</span>
-                      <span class="session-item__detail">{item.detail}</span>
-                      <span class="session-item__time">{item.time}</span>
-                    </div>
-                  {/each}
-                </div>
-              </div>
-            </div>
+            <ActivityPanel {transferHistory} {sessionLog} {formatSize} {formatDuration} {formatTransferTime} />
           </div>
         {/if}
         </div>
@@ -905,47 +866,7 @@
             </div>
           {/if}
 
-          <div class="activity-panel">
-            <div class="activity-column">
-              <div class="activity-header">
-                <h3>TRANSFER HISTORY</h3>
-                <span>{transferHistory.length}</span>
-              </div>
-              <div class="activity-list" class:empty={transferHistory.length === 0}>
-                {#if transferHistory.length === 0}
-                  <p>No transfers recorded in this session</p>
-                {/if}
-                {#each transferHistory as item (item.id)}
-                  <div class="activity-item activity-item--{item.status}">
-                    <span class="activity-item__name">{item.filename}</span>
-                    <span class="activity-item__meta">
-                      {item.direction === "send" ? "SENT" : "RECEIVED"} · {formatSize(item.sizeBytes)} · {formatDuration(item.durationMillis)}
-                    </span>
-                    <span class="activity-item__time">{formatTransferTime(item.completedAt)}</span>
-                  </div>
-                {/each}
-              </div>
-            </div>
-
-            <div class="activity-column">
-              <div class="activity-header">
-                <h3>SESSION LOG</h3>
-                <span>{sessionLog.length}</span>
-              </div>
-              <div class="activity-list" class:empty={sessionLog.length === 0}>
-                {#if sessionLog.length === 0}
-                  <p>Session events will appear here</p>
-                {/if}
-                {#each sessionLog as item (item.id)}
-                  <div class="session-item session-item--{item.type}">
-                    <span class="session-item__title">{item.title}</span>
-                    <span class="session-item__detail">{item.detail}</span>
-                    <span class="session-item__time">{item.time}</span>
-                  </div>
-                {/each}
-              </div>
-            </div>
-          </div>
+          <ActivityPanel {transferHistory} {sessionLog} {formatSize} {formatDuration} {formatTransferTime} />
         </div>
       {:else if mode === "SETTINGS"}
         <div class="mode-wrapper" in:fly={{ y: 15, duration: 250 }}>
@@ -1590,118 +1511,6 @@
     font-family: var(--nb-font-mono);
     font-size: var(--nb-text-xs);
     color: var(--nb-text-muted);
-  }
-
-  .activity-panel {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--nb-space-4);
-    width: 100%;
-  }
-
-  .activity-column {
-    background: var(--nb-surface);
-    border: var(--nb-border-lg);
-    box-shadow: var(--nb-shadow-md);
-    min-width: 0;
-  }
-
-  .activity-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--nb-space-3);
-    background: var(--nb-bg);
-    border-bottom: var(--nb-border-lg);
-    padding: var(--nb-space-3) var(--nb-space-4);
-  }
-
-  .activity-header h3 {
-    margin: 0;
-    font-family: var(--nb-font-display);
-    font-size: var(--nb-text-sm);
-    font-weight: 800;
-    letter-spacing: 0.05em;
-  }
-
-  .activity-header span {
-    font-family: var(--nb-font-mono);
-    font-size: var(--nb-text-xs);
-    font-weight: 800;
-    background: var(--nb-secondary);
-    color: var(--nb-secondary-text);
-    border: var(--nb-border-md);
-    padding: 2px 8px;
-  }
-
-  .activity-list {
-    max-height: 220px;
-    overflow-y: auto;
-  }
-
-  .activity-list.empty {
-    padding: var(--nb-space-4);
-  }
-
-  .activity-list.empty p {
-    margin: 0;
-    color: var(--nb-text-muted);
-    font-family: var(--nb-font-mono);
-    font-size: var(--nb-text-xs);
-    font-weight: 700;
-    text-align: center;
-  }
-
-  .activity-item,
-  .session-item {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 4px var(--nb-space-3);
-    padding: var(--nb-space-3) var(--nb-space-4);
-    border-bottom: 1px solid var(--nb-border-color);
-    min-width: 0;
-  }
-
-  .activity-item--failed,
-  .session-item--error {
-    background: rgba(255, 107, 107, 0.12);
-  }
-
-  .session-item--warn {
-    background: rgba(255, 176, 0, 0.12);
-  }
-
-  .activity-item__name,
-  .session-item__title {
-    font-weight: 800;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .activity-item__meta,
-  .session-item__detail {
-    grid-column: 1 / -1;
-    font-family: var(--nb-font-mono);
-    font-size: var(--nb-text-xs);
-    color: var(--nb-text-muted);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .activity-item__time,
-  .session-item__time {
-    font-family: var(--nb-font-mono);
-    font-size: var(--nb-text-xs);
-    font-weight: 800;
-    color: var(--nb-text-muted);
-  }
-
-  @media (max-width: 760px) {
-    .activity-panel {
-      grid-template-columns: 1fr;
-    }
   }
 
   /* Sender Dialog */

--- a/desktop/frontend/src/design-system/ActivityPanel.svelte
+++ b/desktop/frontend/src/design-system/ActivityPanel.svelte
@@ -1,0 +1,163 @@
+<script>
+  export let transferHistory = [];
+  export let sessionLog = [];
+  export let formatSize;
+  export let formatDuration;
+  export let formatTransferTime;
+</script>
+
+<div class="activity-panel">
+  <div class="activity-column">
+    <div class="activity-header">
+      <h3>TRANSFER HISTORY</h3>
+      <span>{transferHistory.length}</span>
+    </div>
+    <div class="activity-list" class:empty={transferHistory.length === 0}>
+      {#if transferHistory.length === 0}
+        <p>No transfers recorded in this session</p>
+      {/if}
+      {#each transferHistory as item (item.id)}
+        <div class="activity-item activity-item--{item.status}">
+          <span class="activity-item__name">{item.filename}</span>
+          <span class="activity-item__meta">
+            {item.direction === "send" ? "SENT" : "RECEIVED"} · {formatSize(item.sizeBytes)} · {formatDuration(item.durationMillis)}
+          </span>
+          <span class="activity-item__time">{formatTransferTime(item.completedAt)}</span>
+        </div>
+      {/each}
+    </div>
+  </div>
+
+  <div class="activity-column">
+    <div class="activity-header">
+      <h3>SESSION LOG</h3>
+      <span>{sessionLog.length}</span>
+    </div>
+    <div class="activity-list" class:empty={sessionLog.length === 0}>
+      {#if sessionLog.length === 0}
+        <p>Session events will appear here</p>
+      {/if}
+      {#each sessionLog as item (item.id)}
+        <div class="session-item session-item--{item.type}">
+          <span class="session-item__title">{item.title}</span>
+          <span class="session-item__detail">{item.detail}</span>
+          <span class="session-item__time">{item.time}</span>
+        </div>
+      {/each}
+    </div>
+  </div>
+</div>
+
+<style>
+  .activity-panel {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--nb-space-4);
+    width: 100%;
+  }
+
+  .activity-column {
+    background: var(--nb-surface);
+    border: var(--nb-border-lg);
+    box-shadow: var(--nb-shadow-md);
+    min-width: 0;
+  }
+
+  .activity-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--nb-space-3);
+    background: var(--nb-bg);
+    border-bottom: var(--nb-border-lg);
+    padding: var(--nb-space-3) var(--nb-space-4);
+  }
+
+  .activity-header h3 {
+    margin: 0;
+    font-family: var(--nb-font-display);
+    font-size: var(--nb-text-sm);
+    font-weight: 800;
+    letter-spacing: 0.05em;
+  }
+
+  .activity-header span {
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    font-weight: 800;
+    background: var(--nb-secondary);
+    color: var(--nb-secondary-text);
+    border: var(--nb-border-md);
+    padding: 2px 8px;
+  }
+
+  .activity-list {
+    max-height: 220px;
+    overflow-y: auto;
+  }
+
+  .activity-list.empty {
+    padding: var(--nb-space-4);
+  }
+
+  .activity-list.empty p {
+    margin: 0;
+    color: var(--nb-text-muted);
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    font-weight: 700;
+    text-align: center;
+  }
+
+  .activity-item,
+  .session-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 4px var(--nb-space-3);
+    padding: var(--nb-space-3) var(--nb-space-4);
+    border-bottom: 1px solid var(--nb-border-color);
+    min-width: 0;
+  }
+
+  .activity-item--failed,
+  .session-item--error {
+    background: rgba(255, 107, 107, 0.12);
+  }
+
+  .session-item--warn {
+    background: rgba(255, 176, 0, 0.12);
+  }
+
+  .activity-item__name,
+  .session-item__title {
+    font-weight: 800;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .activity-item__meta,
+  .session-item__detail {
+    grid-column: 1 / -1;
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    color: var(--nb-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .activity-item__time,
+  .session-item__time {
+    font-family: var(--nb-font-mono);
+    font-size: var(--nb-text-xs);
+    font-weight: 800;
+    color: var(--nb-text-muted);
+  }
+
+  @media (max-width: 760px) {
+    .activity-panel {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/desktop/frontend/src/design-system/index.js
+++ b/desktop/frontend/src/design-system/index.js
@@ -16,3 +16,4 @@ export { default as TransferProgressBar  } from './TransferProgressBar.svelte';
 export { default as ConnectedDevicesPanel} from './ConnectedDevicesPanel.svelte';
 export { default as TopNavBar            } from './TopNavBar.svelte';
 export { default as TransferComplete     } from './TransferComplete.svelte';
+export { default as ActivityPanel        } from './ActivityPanel.svelte';


### PR DESCRIPTION
## Summary
- add a concurrency-safe in-memory transfer history for receiver and sender sessions
- emit `transfer_logged` events when uploads/downloads complete or fail
- show transfer history and session log panels in the receive/send UI
- add focused history unit tests for ordering, retention, defensive copies, and timing metadata

## Validation
- `go test ./...` from `beamsync/`
- `go test ./...` from `desktop/`
- `npm --prefix desktop/frontend run build`
- `git diff --check`

Closes #15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transfer history tracking that captures metadata for all send and receive operations within a session, including timestamps, file sizes, and transfer status.
  * Introduced an activity panel displaying recent transfers with direction (send/receive), completion status, and duration information for easier monitoring.
  * Transfer history is automatically cleared when resetting the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PranavAgarkar07/BeamSync/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->