### PR TITLE
Docs/network requirements readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ BeamSync works by creating direct peer-to-peer connections over your Local Area 
 
 ### Important Requirements
 
-- All devices must be connected to the **same local network / subnet**
+- All devices must be connected to the **same local network / subnet**. Devices on different VLANs or isolated network segments may not be able to discover each other.
 - Both devices should be able to communicate with each other over LAN
 - Devices must allow local network access permissions (especially on macOS/mobile hotspots)
 
@@ -170,13 +170,15 @@ BeamSync works by creating direct peer-to-peer connections over your Local Area 
 The following network types may block or limit BeamSync functionality:
 
 - **Guest WiFi networks** often isolate devices from each other
-- **Public networks (cafes, airports, offices)** may block peer-to-peer traffic
-- **Enterprise or school networks** may restrict local device communication
+- **Public WiFi networks (cafes, airports, hotels)** often restrict peer-to-peer traffic
+- **Enterprise, office, or school networks** may use client isolation or VLAN segmentation that prevents devices from discovering each other
 - Some routers may have **AP isolation / client isolation enabled**
+- Some mobile hotspots may use NAT or client isolation, which can interfere with device discovery and peer-to-peer communication.
 
 ### Firewall & Router Considerations
 
 - Firewalls on Linux, Windows, or macOS may block incoming connections
+- BeamSync uses TCP ports **3000–3100** for local transfers. Ensure these ports are allowed through your firewall when necessary.
 - Router settings like **AP isolation** or **client isolation** can prevent device discovery
 - Ensure BeamSync is allowed through system firewall if prompted
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ The following network types may block or limit BeamSync functionality:
 ### Firewall & Router Considerations
 
 - Firewalls on Linux, Windows, or macOS may block incoming connections
-- BeamSync uses TCP ports **3000–3100** for local transfers. Ensure these ports are allowed through your firewall when necessary.
+- BeamSync uses TCP ports **3000–3098** for local transfers. Ensure these ports are allowed through your firewall when necessary.
+- On Linux, BeamSync can automatically configure firewall rules when required through its built-in firewall setup mechanism.
 - Router settings like **AP isolation** or **client isolation** can prevent device discovery
 - Ensure BeamSync is allowed through system firewall if prompted
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,38 @@ Download the latest release from the [Releases](https://github.com/PranavAgarkar
 3. A unique URL and QR code are generated.
 4. Open the URL or scan the QR on the receiving device to start the download.
 
+## Network Requirements & Connectivity Notes
+
+BeamSync works by creating direct peer-to-peer connections over your Local Area Network (LAN). In some network environments, device discovery or file transfers may not work as expected.
+
+### Important Requirements
+
+- All devices must be connected to the **same local network / subnet**
+- Both devices should be able to communicate with each other over LAN
+- Devices must allow local network access permissions (especially on macOS/mobile hotspots)
+
+### Common Network Restrictions
+
+The following network types may block or limit BeamSync functionality:
+
+- **Guest WiFi networks** often isolate devices from each other
+- **Public networks (cafes, airports, offices)** may block peer-to-peer traffic
+- **Enterprise or school networks** may restrict local device communication
+- Some routers may have **AP isolation / client isolation enabled**
+
+### Firewall & Router Considerations
+
+- Firewalls on Linux, Windows, or macOS may block incoming connections
+- Router settings like **AP isolation** or **client isolation** can prevent device discovery
+- Ensure BeamSync is allowed through system firewall if prompted
+
+### Troubleshooting Tip
+
+If devices cannot connect:
+- Confirm both devices are on the same WiFi network
+- Try disabling VPNs or proxies
+- Switch to a mobile hotspot or home network for testing
+
 ## Developer API
 
 For developers, contributors, and security auditors who want to understand the underlying peer-to-peer file transfer protocol or build custom scripts/clients, the complete HTTP API and authentication specifications are available in the **[API Documentation (API.md)](API.md)**.


### PR DESCRIPTION
## Description

Adds a new **Network Requirements & Connectivity Notes** section to the README to help users understand common LAN networking requirements, connectivity limitations, firewall considerations, and troubleshooting steps for BeamSync.

## Related Issue(s)

Fixes #37

## Motivation and Context

BeamSync relies on direct peer-to-peer communication over a local network. Users may encounter connectivity issues due to guest WiFi restrictions, VLAN segmentation, firewall rules, client isolation, or mobile hotspot behavior without understanding the underlying cause.

This documentation update improves onboarding and troubleshooting by clearly explaining:

* Same subnet/VLAN requirements
* Guest network limitations
* Public and enterprise WiFi restrictions
* Mobile hotspot NAT/client isolation issues
* Firewall and port requirements
* Common troubleshooting steps

## How Has This Been Tested?

* [ ] Unit tests added (if applicable)
* [ ] Integration tests added (if applicable)
* [x] Manual testing steps performed:

  * Reviewed BeamSync networking documentation for accuracy
  * Verified firewall configuration script and port usage
  * Confirmed documented port range (3000–3098) matches implementation
  * Checked README formatting and section placement

## Types of Changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Documentation update
* [ ] Refactoring / code cleanup
* [ ] Performance improvement

## Checklist

* [x] My code follows the project’s style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally
* [x] I have updated the relevant documentation (if any)

## Screenshots (if applicable)

N/A – Documentation-only change.
