### PR TITLE
test: cover backend helpers with permissions, port manager, and server tests

### DIFF
--- a/beamsync/permissions_test.go
+++ b/beamsync/permissions_test.go
@@ -14,6 +14,12 @@ func TestDefaultTransferSettings(t *testing.T) {
 	if len(settings.BlockedExtensions) != 0 {
 		t.Fatalf("default blocked extensions = %v, want empty", settings.BlockedExtensions)
 	}
+	if len(settings.TrustedDevices) != 0 {
+		t.Fatalf("default trusted devices = %v, want empty", settings.TrustedDevices)
+	}
+	if len(settings.BlockedDevices) != 0 {
+		t.Fatalf("default blocked devices = %v, want empty", settings.BlockedDevices)
+	}
 }
 
 func TestTransferSettingsDeviceRules(t *testing.T) {

--- a/beamsync/port_manager_test.go
+++ b/beamsync/port_manager_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestFindAvailablePortSkipsBusyPorts(t *testing.T) {
-	busy, err := net.Listen("tcp", "127.0.0.1:0")
+	busy, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("listen on random port: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestFindAvailablePortSkipsBusyPorts(t *testing.T) {
 }
 
 func TestFindAvailablePortReportsExhaustion(t *testing.T) {
-	busy, err := net.Listen("tcp", "127.0.0.1:0")
+	busy, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("listen on random port: %v", err)
 	}

--- a/beamsync/server_test.go
+++ b/beamsync/server_test.go
@@ -234,7 +234,6 @@ func TestStartWriteWorkersProcessesJobsAndIgnoresCreateErrors(t *testing.T) {
 
 func TestStartServerLifecycleRootAndHeartbeat(t *testing.T) {
 	server, baseURL, token, events, _ := startServerForTest(t)
-	defer server.Shutdown()
 
 	resp, err := http.Get(baseURL + "/")
 	if err != nil {


### PR DESCRIPTION
## Summary
- add unit tests for transfer permission defaults, device rules, and blocked extensions
- add port manager tests for busy-port skipping and exhaustion behavior
- add server helper tests for token middleware, auto-renaming, and token format
- use ':0' bind address in port tests to match production behavior
- remove redundant server.Shutdown() in lifecycle test

Closes #14

---

This is a replacement PR for #30 (closed due to a merge workflow issue). The changes are identical to those contributed by @kunal-9090.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced default configuration validation tests to ensure all expected empty security-related collections are properly initialized and verified.
  * Improved port selection test robustness and reliability by updating the network binding mechanism to use dynamic port allocation for better cross-platform compatibility.
  * Removed redundant cleanup code and duplicate shutdown operations in server lifecycle tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->