### PR TITLE
perf: reuse chunk copy buffers

### DIFF
--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -30,6 +30,13 @@ type EventCallback func(eventName string, data string)
 //go:embed ui/*.html ui/*.png
 var uiFS embed.FS
 
+var chunkBufferPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 8*1024*1024)
+		return &buf
+	},
+}
+
 // serverState holds per-instance connection tracking (no more package-level globals).
 type serverState struct {
 	mu             sync.Mutex
@@ -308,7 +315,14 @@ func (dw *downloadProgressWriter) Write(p []byte) (int, error) {
 // copyChunked accumulates those 4 KB reads into a single chunkSize Write(),
 // giving the OS large sequential disk I/O instead of random small writes.
 func copyChunked(dst io.Writer, src io.Reader, chunkSize int) (int64, error) {
-	buf := make([]byte, chunkSize)
+	var buf []byte
+	if chunkSize == 8*1024*1024 {
+		bufPtr := chunkBufferPool.Get().(*[]byte)
+		defer chunkBufferPool.Put(bufPtr)
+		buf = *bufPtr
+	} else {
+		buf = make([]byte, chunkSize)
+	}
 	var total int64
 	for {
 		n, err := io.ReadFull(src, buf)


### PR DESCRIPTION
## Summary
- Fixes #52
- Adds a package-level sync.Pool for the standard 8MB copy buffer
- Reuses buffers in copyChunked instead of allocating a fresh buffer for every file copy
- Keeps non-standard chunk sizes on the existing direct allocation path

## GSSoC
- Label: gssoc:approved
- Level: level:beginner
- Type: type:performance

## Validation
- Not run locally: Go toolchain is not installed in this Codex environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal buffer management strategy in data transfer operations to improve overall memory efficiency and system performance. Implemented intelligent buffer reuse mechanisms that significantly reduce memory allocation overhead during file synchronization tasks. This optimization enhances system responsiveness and improves performance particularly for standard transfer configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->