### PR TITLE
fix: prevent file drops from navigating webview

### DIFF
--- a/desktop/frontend/src/App.svelte
+++ b/desktop/frontend/src/App.svelte
@@ -697,14 +697,18 @@
   // Drag & drop
   function handleDragEnter(e) {
     e.preventDefault();
+    e.stopPropagation();
     dragCounter += 1;
     isDragOver = true;
   }
   function handleDragOver(e) {
     e.preventDefault();
+    e.stopPropagation();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
   }
   function handleDragLeave(e) {
     e.preventDefault();
+    e.stopPropagation();
     dragCounter -= 1;
     if (dragCounter <= 0) {
       dragCounter = 0;
@@ -723,6 +727,7 @@
 
   function handleDrop(e) {
     e.preventDefault();
+    e.stopPropagation();
     dragCounter = 0;
     isDragOver = false;
     if (dropGuard) return;
@@ -758,7 +763,13 @@
   $: sortedFiles = [...receivedFiles];
 </script>
 
-<svelte:window on:mousemove={handleMouseMove} />
+<svelte:window
+  on:mousemove={handleMouseMove}
+  on:dragenter={handleDragEnter}
+  on:dragover={handleDragOver}
+  on:dragleave={handleDragLeave}
+  on:drop={handleDrop}
+/>
 
 {#if transferRequest}
   <div class="nb-card" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 10000; width: 440px; padding: 2.5rem; border: 4px solid var(--nb-border-color); background: var(--nb-surface);">


### PR DESCRIPTION
## Summary
- attach drag/drop handlers at the Svelte window level
- stop propagation and prevent browser default file navigation for dragged files
- set copy drop effect while preserving the existing native Wails drop flow

Fixes #44

## Validation
- Not run locally: frontend dependencies are not installed in this checkout.