### PR TITLE
fix: restrict cors to public ui routes

### DIFF
--- a/beamsync/resumable_upload.go
+++ b/beamsync/resumable_upload.go
@@ -41,7 +41,6 @@ type resumableManifest struct {
 
 func handleResumableUpload(uploadDir string, state *serverState, emit func(string, string)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		setCORSHeaders(w)
 		w.Header().Set("Accept-Ranges", "bytes")
 		if r.Method != http.MethodPut && r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -151,7 +150,6 @@ func handleResumableUpload(uploadDir string, state *serverState, emit func(strin
 
 func handleResumableUploadStatus(uploadDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		setCORSHeaders(w)
 		w.Header().Set("Accept-Ranges", "bytes")
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -494,7 +494,6 @@ func generateToken() string {
 // Exempt routes: "/" (serves UI page).
 func tokenMiddleware(token string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		setCORSHeaders(w)
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -550,7 +549,6 @@ func rateLimitMiddleware(limiter *clientRateLimiter, settings *TransferSettings,
 	return func(w http.ResponseWriter, r *http.Request) {
 		isUI := r.URL.Path == "/" || r.URL.Path == "/logo.png"
 		if !isUI {
-			setCORSHeaders(w)
 			if r.Method == http.MethodOptions {
 				w.WriteHeader(http.StatusNoContent)
 				return
@@ -725,6 +723,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 			return
 		}
 		fmt.Println("🌐 GET / - Serving upload UI")
+		setCORSHeaders(w)
 		content, err := uiFS.ReadFile("ui/upload.html")
 		if err != nil {
 			http.Error(w, "UI Load Error", http.StatusInternalServerError)
@@ -745,6 +744,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 	}))
 
 	mux.HandleFunc("/logo.png", rateLimitMiddleware(pageLimiter, httpServer.settings, func(w http.ResponseWriter, r *http.Request) {
+		setCORSHeaders(w)
 		w.Header().Set("Cache-Control", "public, max-age=31536000")
 		w.Header().Set("Content-Type", "image/png")
 		content, err := uiFS.ReadFile("ui/logo.png")
@@ -756,7 +756,6 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 	}))
 
 	mux.HandleFunc("/stats", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
-		setCORSHeaders(w)
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -769,7 +768,6 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 
 	// ── Request Transfer (ask before accepting) ──────────────────────────────
 	mux.HandleFunc("/request-transfer", rateLimitMiddleware(transferLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
-		setCORSHeaders(w)
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -1281,6 +1279,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 	}
 
 	mux.HandleFunc("/", rateLimitMiddleware(pageLimiter, httpServer.settings, func(w http.ResponseWriter, r *http.Request) {
+		setCORSHeaders(w)
 		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 		w.Header().Set("Content-Type", "text/html")
 		content, err := uiFS.ReadFile("ui/download.html")
@@ -1294,6 +1293,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 	}))
 
 	mux.HandleFunc("/logo.png", rateLimitMiddleware(pageLimiter, httpServer.settings, func(w http.ResponseWriter, r *http.Request) {
+		setCORSHeaders(w)
 		w.Header().Set("Cache-Control", "public, max-age=31536000")
 		w.Header().Set("Content-Type", "image/png")
 		content, err := uiFS.ReadFile("ui/logo.png")
@@ -1308,7 +1308,6 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 		filePath := filePaths[0]
 		filename := filepath.Base(filePath)
 		mux.HandleFunc("/download", rateLimitMiddleware(downloadLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
-			setCORSHeaders(w)
 			activeDownloads := atomic.AddInt32(&state.uploadingCount, 1)
 			emit("transfer_stats", transferStatsJSON(httpServer.stats.snapshotDownloads(activeDownloads)))
 			defer func() {
@@ -1380,7 +1379,6 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 			idx := i
 			filePath := path
 			mux.HandleFunc(fmt.Sprintf("/download/%d", idx), rateLimitMiddleware(downloadLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
-				setCORSHeaders(w)
 				realName := filepath.Base(filePath)
 				activeDownloads := atomic.AddInt32(&state.uploadingCount, 1)
 				emit("transfer_stats", transferStatsJSON(httpServer.stats.snapshotDownloads(activeDownloads)))

--- a/beamsync/server_test.go
+++ b/beamsync/server_test.go
@@ -31,6 +31,9 @@ func TestTokenMiddlewareRejectsMissingOrInvalidToken(t *testing.T) {
 		if rec.Code != http.StatusForbidden {
 			t.Fatalf("%s returned %d, want %d", target, rec.Code, http.StatusForbidden)
 		}
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Fatalf("%s set Access-Control-Allow-Origin = %q, want empty", target, got)
+		}
 	}
 }
 
@@ -45,12 +48,18 @@ func TestTokenMiddlewareAllowsValidTokenAndOptions(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("valid token status = %d, want %d", rec.Code, http.StatusAccepted)
 	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("valid token response set Access-Control-Allow-Origin = %q, want empty", got)
+	}
 
 	optionsReq := httptest.NewRequest(http.MethodOptions, "/upload", nil)
 	optionsRec := httptest.NewRecorder()
 	handler(optionsRec, optionsReq)
 	if optionsRec.Code != http.StatusNoContent {
 		t.Fatalf("OPTIONS status = %d, want %d", optionsRec.Code, http.StatusNoContent)
+	}
+	if got := optionsRec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("OPTIONS response set Access-Control-Allow-Origin = %q, want empty", got)
 	}
 }
 
@@ -247,6 +256,9 @@ func TestStartServerLifecycleRootAndHeartbeat(t *testing.T) {
 	if !strings.Contains(resp.Header.Get("Content-Type"), "text/html") {
 		t.Fatalf("Content-Type = %q, want text/html", resp.Header.Get("Content-Type"))
 	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("root Access-Control-Allow-Origin = %q, want *", got)
+	}
 	if !strings.Contains(string(body), token) {
 		t.Fatal("root page did not include session token")
 	}
@@ -262,6 +274,9 @@ func TestStartServerLifecycleRootAndHeartbeat(t *testing.T) {
 	heartbeatResp.Body.Close()
 	if heartbeatResp.StatusCode != http.StatusOK {
 		t.Fatalf("heartbeat status = %d, want %d", heartbeatResp.StatusCode, http.StatusOK)
+	}
+	if got := heartbeatResp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("heartbeat Access-Control-Allow-Origin = %q, want empty", got)
 	}
 
 	if !waitForEvent(events, "device_connected", time.Second) {
@@ -289,6 +304,9 @@ func TestUploadWithoutFileReturnsBadRequest(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("upload status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("upload Access-Control-Allow-Origin = %q, want empty", got)
 	}
 }
 
@@ -344,6 +362,9 @@ func TestUploadWithFileSavesToDiskAndEmitsEvents(t *testing.T) {
 	defer statsResp.Body.Close()
 	if statsResp.StatusCode != http.StatusOK {
 		t.Fatalf("stats status = %d, want %d", statsResp.StatusCode, http.StatusOK)
+	}
+	if got := statsResp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("stats Access-Control-Allow-Origin = %q, want empty", got)
 	}
 	var stats TransferStats
 	if err := json.NewDecoder(statsResp.Body).Decode(&stats); err != nil {


### PR DESCRIPTION
﻿## Summary
- remove wildcard CORS from token and rate-limit middleware so protected API routes do not expose responses cross-origin
- keep wildcard CORS only on public UI-serving routes (`/` and `/logo.png`) for receiver and sender modes
- remove CORS from token-protected stats, request-transfer, upload/resumable, upload-status, and download routes
- add regression assertions for token middleware, root UI, heartbeat, upload, and stats responses

Closes #46

## Testing
- `git diff --check`
- Not run: `go test ./...` because Go is not installed on this Windows runner, and a `winget install GoLang.Go` attempt stalled before installing `go`/`gofmt`.
