### PR TITLE
refactor: use ring buffer for transfer history

### DIFF
--- a/beamsync/history.go
+++ b/beamsync/history.go
@@ -35,6 +35,8 @@ type TransferHistory struct {
 	maxEntries int
 	nextID     uint64
 	entries    []TransferRecord
+	start      int
+	count      int
 }
 
 func NewTransferHistory(maxEntries int) *TransferHistory {
@@ -52,6 +54,10 @@ func (h *TransferHistory) Add(record TransferRecord) TransferRecord {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	if h.maxEntries <= 0 {
+		h.maxEntries = defaultTransferHistoryLimit
+	}
+
 	h.nextID++
 	if record.ID == "" {
 		record.ID = fmt.Sprintf("transfer-%d-%d", time.Now().UnixNano(), h.nextID)
@@ -66,9 +72,14 @@ func (h *TransferHistory) Add(record TransferRecord) TransferRecord {
 		record.DurationMillis = record.CompletedAt.Sub(record.StartedAt).Milliseconds()
 	}
 
-	h.entries = append([]TransferRecord{record}, h.entries...)
-	if len(h.entries) > h.maxEntries {
-		h.entries = h.entries[:h.maxEntries]
+	if len(h.entries) == 0 {
+		h.entries = make([]TransferRecord, h.maxEntries)
+	}
+
+	h.start = (h.start - 1 + h.maxEntries) % h.maxEntries
+	h.entries[h.start] = record
+	if h.count < h.maxEntries {
+		h.count++
 	}
 	return record
 }
@@ -81,7 +92,9 @@ func (h *TransferHistory) List() []TransferRecord {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	records := make([]TransferRecord, len(h.entries))
-	copy(records, h.entries)
+	records := make([]TransferRecord, h.count)
+	for i := 0; i < h.count; i++ {
+		records[i] = h.entries[(h.start+i)%h.maxEntries]
+	}
 	return records
 }

--- a/beamsync/history_test.go
+++ b/beamsync/history_test.go
@@ -1,6 +1,7 @@
 package beamsync
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -38,6 +39,30 @@ func TestTransferHistoryCopiesEntries(t *testing.T) {
 	}
 }
 
+func TestTransferHistoryRingBufferWrapsNewestFirst(t *testing.T) {
+	history := NewTransferHistory(3)
+
+	for i := 1; i <= 6; i++ {
+		history.Add(TransferRecord{
+			Filename:  fmt.Sprintf("file-%d.txt", i),
+			Direction: TransferDirectionReceive,
+			Status:    TransferStatusCompleted,
+		})
+	}
+
+	records := history.List()
+	if len(records) != 3 {
+		t.Fatalf("expected capped history length 3, got %d", len(records))
+	}
+
+	want := []string{"file-6.txt", "file-5.txt", "file-4.txt"}
+	for i, filename := range want {
+		if records[i].Filename != filename {
+			t.Fatalf("record %d filename = %q, want %q; records=%#v", i, records[i].Filename, filename, records)
+		}
+	}
+}
+
 func TestTransferHistoryFillsTimingMetadata(t *testing.T) {
 	history := NewTransferHistory(10)
 	startedAt := time.Now().Add(-2 * time.Second)
@@ -53,5 +78,25 @@ func TestTransferHistoryFillsTimingMetadata(t *testing.T) {
 	}
 	if record.DurationMillis <= 0 {
 		t.Fatalf("expected positive duration, got %d", record.DurationMillis)
+	}
+}
+
+func BenchmarkTransferHistoryAddAtCapacity(b *testing.B) {
+	history := NewTransferHistory(100)
+	for i := 0; i < 100; i++ {
+		history.Add(TransferRecord{
+			Filename:  fmt.Sprintf("warmup-%d.txt", i),
+			Direction: TransferDirectionReceive,
+			Status:    TransferStatusCompleted,
+		})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		history.Add(TransferRecord{
+			Filename:  "file.txt",
+			Direction: TransferDirectionReceive,
+			Status:    TransferStatusCompleted,
+		})
 	}
 }


### PR DESCRIPTION
﻿## Summary
- replace transfer history prepend-copy behavior with a fixed-size ring buffer
- keep `List()` returning newest-first records with a defensive copy
- preserve generated IDs, timestamps, duration metadata, and capacity behavior
- add wraparound regression coverage and an at-capacity Add benchmark

Closes #53

## Testing
- `git diff --check`
- Not run: `go test ./...` / `go test -bench` because Go is not installed on this Windows runner, and an earlier `winget install GoLang.Go` attempt stalled before installing `go`/`gofmt`.
