### PR TITLE
fix: bound backend event dispatch

### DIFF
--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -27,6 +27,58 @@ import (
 
 type EventCallback func(eventName string, data string)
 
+const eventDispatcherBufferSize = 256
+
+type eventDispatchJob struct {
+	emit  EventCallback
+	event string
+	data  string
+}
+
+type eventDispatcher struct {
+	queue chan eventDispatchJob
+}
+
+func newEventDispatcher(bufferSize int) *eventDispatcher {
+	if bufferSize <= 0 {
+		bufferSize = eventDispatcherBufferSize
+	}
+	dispatcher := &eventDispatcher{
+		queue: make(chan eventDispatchJob, bufferSize),
+	}
+	go dispatcher.run()
+	return dispatcher
+}
+
+func (d *eventDispatcher) run() {
+	for job := range d.queue {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Printf("Event callback panic: %v\n", r)
+				}
+			}()
+			if job.emit != nil {
+				job.emit(job.event, job.data)
+			}
+		}()
+	}
+}
+
+func (d *eventDispatcher) emit(job eventDispatchJob) bool {
+	if job.emit == nil {
+		return true
+	}
+	select {
+	case d.queue <- job:
+		return true
+	default:
+		return false
+	}
+}
+
+var defaultEventDispatcher = newEventDispatcher(eventDispatcherBufferSize)
+
 //go:embed ui/*.html ui/*.png
 var uiFS embed.FS
 
@@ -633,20 +685,14 @@ func startWatchdog(ctx context.Context, state *serverState, emit func(string, st
 	}()
 }
 
-// safeEmit dispatches an event in its own goroutine with panic recovery.
+// safeEmit queues an event without spawning a goroutine per notification.
 func safeEmit(emit EventCallback, event, data string) {
-	go func(evt, dt string) {
-		defer func() {
-			if r := recover(); r != nil {
-				fmt.Printf("⚠️ Event callback panic: %v\n", r)
-			}
-		}()
-		fmt.Printf("📡 Emitting event: %s | data: %s\n", evt, dt)
-		if emit != nil {
-			emit(evt, dt)
-			fmt.Printf("✅ Event emitted: %s\n", evt)
-		}
-	}(event, data)
+	if emit == nil {
+		return
+	}
+	if !defaultEventDispatcher.emit(eventDispatchJob{emit: emit, event: event, data: data}) {
+		fmt.Printf("Dropping event because dispatch queue is full: %s\n", event)
+	}
 }
 
 func logTransfer(history *TransferHistory, emit func(string, string), record TransferRecord) {

--- a/beamsync/server_test.go
+++ b/beamsync/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -136,6 +137,36 @@ func TestSafeEmitHandlesNilCallbackAndCallbackPanic(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("safeEmit did not invoke callback")
+	}
+}
+
+func TestSafeEmitDoesNotSpawnPerEventGoroutines(t *testing.T) {
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	callback := func(string, string) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-block
+	}
+
+	before := runtime.NumGoroutine()
+	for i := 0; i < 50; i++ {
+		safeEmit(callback, "upload_progress", "file.txt|1|50")
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not start processing events")
+	}
+
+	after := runtime.NumGoroutine()
+	close(block)
+
+	if growth := after - before; growth > 5 {
+		t.Fatalf("goroutine count grew by %d; safeEmit should use one bounded dispatcher", growth)
 	}
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -213,7 +213,11 @@ func (a *App) PlaySound(name string) {
 // makeCallback returns an EventCallback that queues events into the channel.
 func (a *App) makeCallback() beamsync.EventCallback {
 	return func(name string, data string) {
-		a.eventChan <- EventData{Name: name, Data: data}
+		select {
+		case a.eventChan <- EventData{Name: name, Data: data}:
+		default:
+			fmt.Printf("Dropping frontend event because queue is full: %s\n", name)
+		}
 	}
 }
 


### PR DESCRIPTION
﻿## Summary
- replace per-event goroutine spawning in `safeEmit` with a single bounded dispatcher queue
- drop events when the backend dispatch queue is full instead of allowing goroutines to pile up
- make the desktop callback non-blocking when the frontend event channel is full
- add a regression test that floods blocked callbacks and asserts goroutine growth stays bounded

Closes #45

## Testing
- `git diff --check`
- Not run: `go test ./...` because Go is not installed on this Windows runner, and an earlier `winget install GoLang.Go` attempt stalled before installing `go`/`gofmt`.
