### PR TITLE
fix: make shutdown safe during active transfers

### DIFF
--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -307,7 +307,14 @@ func (s *HTTPServer) Shutdown() error {
 		s.cancel()
 	}
 	if s.server != nil {
-		return s.server.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.server.Shutdown(ctx); err != nil {
+			if closeErr := s.server.Close(); closeErr != nil {
+				return fmt.Errorf("graceful shutdown failed: %w; forced close failed: %v", err, closeErr)
+			}
+			return err
+		}
 	}
 	return nil
 }

--- a/beamsync/server_test.go
+++ b/beamsync/server_test.go
@@ -179,6 +179,99 @@ func TestSafeEmitDoesNotSpawnPerEventGoroutines(t *testing.T) {
 	}
 }
 
+func TestHTTPServerShutdownWaitsForActiveRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	httpSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			<-release
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	serveDone := make(chan error, 1)
+	go func() {
+		if err := httpSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			serveDone <- err
+			return
+		}
+		serveDone <- nil
+	}()
+
+	clientDone := make(chan error, 1)
+	go func() {
+		resp, err := http.Get("http://" + ln.Addr().String())
+		if err != nil {
+			clientDone <- err
+			return
+		}
+		defer resp.Body.Close()
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			clientDone <- err
+			return
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			clientDone <- fmt.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+			return
+		}
+		clientDone <- nil
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not receive request")
+	}
+
+	server := &HTTPServer{server: httpSrv}
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- server.Shutdown()
+	}()
+
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("Shutdown returned before active request finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case err := <-clientDone:
+		if err != nil {
+			t.Fatalf("client request: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("client request did not complete")
+	}
+
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			t.Fatalf("shutdown: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not complete after request finished")
+	}
+
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Fatalf("serve: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not exit after shutdown")
+	}
+}
+
 func TestProcessManifestCases(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		got, err := processManifest(strings.NewReader(`[{"name":"a.txt","size":12},{"name":"b.bin","size":34}]`))

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -16,6 +16,7 @@ import (
 	stdruntime "runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -34,6 +35,8 @@ type App struct {
 	serverApp    *beamsync.HTTPServer
 	senderApp    *beamsync.HTTPServer
 	eventChan    chan EventData
+	eventsClosed chan struct{}
+	shutdownOnce sync.Once
 	lastSavePath string
 	currentIP    string
 	currentPort  string
@@ -64,7 +67,8 @@ type ReceivedFile struct {
 // NewApp creates a new App application struct
 func NewApp() *App {
 	return &App{
-		eventChan: make(chan EventData, 100),
+		eventChan:    make(chan EventData, 100),
+		eventsClosed: make(chan struct{}),
 	}
 }
 
@@ -153,17 +157,25 @@ func (a *App) startup(ctx context.Context) {
 
 // processEvents handles backend events on a safe goroutine before relaying to Wails.
 func (a *App) processEvents() {
-	for event := range a.eventChan {
-		if event.Name == "device_connected" {
-			currentRealIP := getLocalIP()
-			if a.currentIP != "" && a.currentIP != currentRealIP {
-				fmt.Printf("🔄 IP Change Detected! Old: %s, New: %s\n", a.currentIP, currentRealIP)
-				a.currentIP = currentRealIP
-				newURL := fmt.Sprintf("%s://%s:%s", beamsync.ServerScheme(), a.currentIP, a.currentPort)
-				a.safeEmit("url_changed", newURL)
+	for {
+		select {
+		case event, ok := <-a.eventChan:
+			if !ok {
+				return
 			}
+			if event.Name == "device_connected" {
+				currentRealIP := getLocalIP()
+				if a.currentIP != "" && a.currentIP != currentRealIP {
+					fmt.Printf("🔄 IP Change Detected! Old: %s, New: %s\n", a.currentIP, currentRealIP)
+					a.currentIP = currentRealIP
+					newURL := fmt.Sprintf("%s://%s:%s", beamsync.ServerScheme(), a.currentIP, a.currentPort)
+					a.safeEmit("url_changed", newURL)
+				}
+			}
+			a.safeEmit(event.Name, event.Data)
+		case <-a.eventsClosed:
+			return
 		}
-		a.safeEmit(event.Name, event.Data)
 	}
 }
 
@@ -184,19 +196,21 @@ func (a *App) safeEmit(eventName string, data interface{}) {
 
 // shutdown is called when the app is closing.
 func (a *App) shutdown(ctx context.Context) {
-	close(a.eventChan)
-	if a.serverApp != nil {
-		fmt.Println("🛑 Shutting down receiver server...")
-		if err := a.serverApp.Shutdown(); err != nil {
-			fmt.Println("⚠️ Server shutdown error:", err)
+	a.shutdownOnce.Do(func() {
+		if a.serverApp != nil {
+			fmt.Println("🛑 Shutting down receiver server...")
+			if err := a.serverApp.Shutdown(); err != nil {
+				fmt.Println("⚠️ Server shutdown error:", err)
+			}
 		}
-	}
-	if a.senderApp != nil {
-		fmt.Println("🛑 Shutting down sender server...")
-		if err := a.senderApp.Shutdown(); err != nil {
-			fmt.Println("⚠️ Sender shutdown error:", err)
+		if a.senderApp != nil {
+			fmt.Println("🛑 Shutting down sender server...")
+			if err := a.senderApp.Shutdown(); err != nil {
+				fmt.Println("⚠️ Sender shutdown error:", err)
+			}
 		}
-	}
+		close(a.eventsClosed)
+	})
 }
 
 // PlaySound is exposed to the frontend.
@@ -214,6 +228,8 @@ func (a *App) PlaySound(name string) {
 func (a *App) makeCallback() beamsync.EventCallback {
 	return func(name string, data string) {
 		select {
+		case <-a.eventsClosed:
+			return
 		case a.eventChan <- EventData{Name: name, Data: data}:
 		default:
 			fmt.Printf("Dropping frontend event because queue is full: %s\n", name)


### PR DESCRIPTION
## Summary
- Prevent shutdown panics by no longer closing `eventChan` while transfer callbacks may still enqueue events
- Add a separate shutdown signal so event processing exits cleanly and late callbacks are dropped safely
- Switch HTTP server shutdown from hard `Close()` to graceful `Shutdown(ctx)` with a forced-close fallback
- Add a regression test proving shutdown waits for an active request to finish

Fixes #47

## Validation
- `git diff --check`
- `go test -run TestHTTPServerShutdownWaitsForActiveRequest -count=1 -v` in `beamsync` (passes with Go 1.25.5)
- `go test ./...` in `beamsync` reaches the existing suite but local Windows profile fails TLS config tests because `C:\Users\Garima Varshney\.config` exists as a file, preventing `os.UserConfigDir()` subdirectory creation
- `go test ./...` in `desktop` requires frontend assets first (`frontend/dist` missing locally), matching the CI order where frontend build runs before desktop Go tests