### PR TITLE
fix: validate regular upload file integrity

### DIFF
--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
@@ -417,6 +418,18 @@ const writeWorkerCount = 3
 // largeFileThreshold is the maximum file size to buffer fully in RAM.
 // Files larger than this are streamed directly to disk.
 const largeFileThreshold = 64 * 1024 * 1024 // 64 MB
+
+const uploadIntegrityHeader = "X-BeamSync-File-SHA256"
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func hashMatches(expected string, actual string) bool {
+	expected = strings.TrimSpace(expected)
+	return expected == "" || strings.EqualFold(expected, actual)
+}
 
 // startWriteWorkers launches writeWorkerCount goroutines that drain jobs and
 // write files to disk. Returns a WaitGroup the caller can Wait() on.
@@ -943,6 +956,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 			return
 		}
 		boundary := params["boundary"]
+		expectedFileSHA256 := strings.TrimSpace(r.Header.Get(uploadIntegrityHeader))
 
 		// 8 MB network read buffer — reduces TCP recv() syscalls dramatically.
 		netReader := bufio.NewReaderSize(r.Body, 8*1024*1024)
@@ -1069,11 +1083,16 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 					emit:        emit,
 					minInterval: 500 * time.Millisecond,
 				}
+				var writeTarget io.Writer = lpw
+				hash := sha256.New()
+				if expectedFileSHA256 != "" {
+					writeTarget = io.MultiWriter(lpw, hash)
+				}
 				// Write the already-buffered prefix first.
 				prefixBytes := buf.Bytes()
-				prefixWritten, prefixErr := lpw.Write(prefixBytes)
+				prefixWritten, prefixErr := writeTarget.Write(prefixBytes)
 				// Stream the remainder from the network.
-				lWritten, lErr := copyChunked(lpw, part, 8*1024*1024)
+				lWritten, lErr := copyChunked(writeTarget, part, 8*1024*1024)
 				lWritten += int64(prefixWritten)
 				flushErr := diskBuf.Flush()
 				dst.Close()
@@ -1102,6 +1121,20 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 					})
 					continue
 				}
+				if !hashMatches(expectedFileSHA256, hex.EncodeToString(hash.Sum(nil))) {
+					_ = os.Remove(dstPath)
+					httpServer.stats.recordIntegrityFailure()
+					logTransfer(httpServer.history, emit, TransferRecord{
+						Filename:  savedName,
+						Direction: TransferDirectionReceive,
+						Status:    TransferStatusFailed,
+						SizeBytes: lWritten,
+						StartedAt: startedAt,
+						Error:     "integrity-mismatch",
+					})
+					parseErr = fmt.Errorf("integrity-mismatch")
+					break
+				}
 				emit("upload_progress", fmt.Sprintf("%s|%d|%d", savedName, lWritten, lWritten))
 				snapshot := httpServer.stats.recordReceived(savedName, lWritten, atomic.LoadInt32(&state.uploadingCount))
 				emit("transfer_stats", transferStatsJSON(snapshot))
@@ -1124,6 +1157,19 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 					fmt.Println("❌ Part read error:", readErr)
 					continue
 				}
+				if !hashMatches(expectedFileSHA256, sha256Hex(buf.Bytes())) {
+					httpServer.stats.recordIntegrityFailure()
+					logTransfer(httpServer.history, emit, TransferRecord{
+						Filename:  savedName,
+						Direction: TransferDirectionReceive,
+						Status:    TransferStatusFailed,
+						SizeBytes: int64(buf.Len()),
+						StartedAt: time.Now(),
+						Error:     "integrity-mismatch",
+					})
+					parseErr = fmt.Errorf("integrity-mismatch")
+					break
+				}
 				jobs <- writeJob{
 					dstPath:   dstPath,
 					savedName: savedName,
@@ -1136,6 +1182,11 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		// Signal workers that no more jobs are coming, then wait for all writes.
 		close(jobs)
 		wg.Wait()
+
+		if parseErr != nil && parseErr.Error() == "integrity-mismatch" {
+			http.Error(w, "integrity-mismatch", http.StatusBadRequest)
+			return
+		}
 
 		if parseErr != nil {
 			http.Error(w, "Multipart read error", http.StatusBadRequest)

--- a/beamsync/server_test.go
+++ b/beamsync/server_test.go
@@ -2,6 +2,8 @@ package beamsync
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -406,6 +408,81 @@ func TestUploadWithFileSavesToDiskAndEmitsEvents(t *testing.T) {
 	}
 }
 
+func TestUploadWithMatchingSHA256HeaderSucceeds(t *testing.T) {
+	server, baseURL, token, _, uploadDir := startServerForTest(t)
+	defer server.Shutdown()
+
+	payload := []byte("hello verified world")
+	body, contentType := multipartUploadBody(t, "verified.txt", payload)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/upload?token="+token, &body)
+	if err != nil {
+		t.Fatalf("create upload request: %v", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set(uploadIntegrityHeader, sha256String(payload))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /upload: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("upload status = %d, want %d: %s", resp.StatusCode, http.StatusOK, responseBody)
+	}
+
+	got, err := os.ReadFile(filepath.Join(uploadDir, "verified.txt"))
+	if err != nil {
+		t.Fatalf("read uploaded file: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("uploaded file = %q, want %q", got, payload)
+	}
+}
+
+func TestUploadWithMismatchedSHA256HeaderRejectsAndRecordsFailure(t *testing.T) {
+	server, baseURL, token, _, uploadDir := startServerForTest(t)
+	defer server.Shutdown()
+
+	payload := []byte("corrupted on the wire")
+	body, contentType := multipartUploadBody(t, "corrupt.txt", payload)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/upload?token="+token, &body)
+	if err != nil {
+		t.Fatalf("create upload request: %v", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set(uploadIntegrityHeader, strings.Repeat("0", 64))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /upload: %v", err)
+	}
+	defer resp.Body.Close()
+	responseBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("upload status = %d, want %d: %s", resp.StatusCode, http.StatusBadRequest, responseBody)
+	}
+	if !strings.Contains(string(responseBody), "integrity-mismatch") {
+		t.Fatalf("response body = %q, want integrity-mismatch", responseBody)
+	}
+	if _, err := os.Stat(filepath.Join(uploadDir, "corrupt.txt")); !os.IsNotExist(err) {
+		t.Fatalf("corrupt file should not be kept, stat err = %v", err)
+	}
+
+	statsResp, err := http.Get(baseURL + "/stats?token=" + token)
+	if err != nil {
+		t.Fatalf("GET /stats: %v", err)
+	}
+	defer statsResp.Body.Close()
+	var stats TransferStats
+	if err := json.NewDecoder(statsResp.Body).Decode(&stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if stats.IntegrityFailures != 1 {
+		t.Fatalf("integrity failures = %d, want 1", stats.IntegrityFailures)
+	}
+}
+
 func eventSeen(mu *sync.Mutex, events *[]string, want string) bool {
 	mu.Lock()
 	defer mu.Unlock()
@@ -450,6 +527,36 @@ func startServerForTest(t *testing.T) (*HTTPServer, string, string, <-chan strin
 		t.Fatalf("StartServer port = %q, want %d", port, startPort)
 	}
 	return server, "http://127.0.0.1:" + port, token, events, uploadDir
+}
+
+func multipartUploadBody(t *testing.T, filename string, payload []byte) (bytes.Buffer, string) {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	manifest, err := writer.CreateFormField("beam_manifest")
+	if err != nil {
+		t.Fatalf("create manifest field: %v", err)
+	}
+	if _, err := fmt.Fprintf(manifest, `[{"name":%q,"size":%d}]`, filename, len(payload)); err != nil {
+		t.Fatalf("write manifest field: %v", err)
+	}
+	file, err := writer.CreateFormFile("files", filename)
+	if err != nil {
+		t.Fatalf("create file field: %v", err)
+	}
+	if _, err := file.Write(payload); err != nil {
+		t.Fatalf("write file field: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	return body, writer.FormDataContentType()
+}
+
+func sha256String(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
 }
 
 func freePort(t *testing.T) int {

--- a/beamsync/stats.go
+++ b/beamsync/stats.go
@@ -7,28 +7,30 @@ import (
 )
 
 type TransferStats struct {
-	StartedAt       string `json:"startedAt"`
-	FilesReceived   int    `json:"filesReceived"`
-	BytesReceived   int64  `json:"bytesReceived"`
-	FilesSent       int    `json:"filesSent"`
-	BytesSent       int64  `json:"bytesSent"`
-	ActiveUploads   int32  `json:"activeUploads"`
-	ActiveDownloads int32  `json:"activeDownloads"`
-	LastFilename    string `json:"lastFilename,omitempty"`
-	LastDirection   string `json:"lastDirection,omitempty"`
-	LastUpdatedAt   string `json:"lastUpdatedAt,omitempty"`
+	StartedAt         string `json:"startedAt"`
+	FilesReceived     int    `json:"filesReceived"`
+	BytesReceived     int64  `json:"bytesReceived"`
+	FilesSent         int    `json:"filesSent"`
+	BytesSent         int64  `json:"bytesSent"`
+	ActiveUploads     int32  `json:"activeUploads"`
+	ActiveDownloads   int32  `json:"activeDownloads"`
+	IntegrityFailures int    `json:"integrityFailures"`
+	LastFilename      string `json:"lastFilename,omitempty"`
+	LastDirection     string `json:"lastDirection,omitempty"`
+	LastUpdatedAt     string `json:"lastUpdatedAt,omitempty"`
 }
 
 type transferStatsTracker struct {
-	mu            sync.Mutex
-	startedAt     time.Time
-	filesReceived int
-	bytesReceived int64
-	filesSent     int
-	bytesSent     int64
-	lastFilename  string
-	lastDirection string
-	lastUpdatedAt time.Time
+	mu                sync.Mutex
+	startedAt         time.Time
+	filesReceived     int
+	bytesReceived     int64
+	filesSent         int
+	bytesSent         int64
+	integrityFailures int
+	lastFilename      string
+	lastDirection     string
+	lastUpdatedAt     time.Time
 }
 
 func newTransferStatsTracker() *transferStatsTracker {
@@ -61,6 +63,16 @@ func (t *transferStatsTracker) recordSent(filename string, bytes int64, activeDo
 	return t.snapshotLocked(0, activeDownloads)
 }
 
+func (t *transferStatsTracker) recordIntegrityFailure() TransferStats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.integrityFailures++
+	t.lastUpdatedAt = time.Now()
+
+	return t.snapshotLocked(0, 0)
+}
+
 func (t *transferStatsTracker) snapshot(activeUploads int32) TransferStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -77,15 +89,16 @@ func (t *transferStatsTracker) snapshotDownloads(activeDownloads int32) Transfer
 
 func (t *transferStatsTracker) snapshotLocked(activeUploads int32, activeDownloads int32) TransferStats {
 	stats := TransferStats{
-		StartedAt:       t.startedAt.Format(time.RFC3339),
-		FilesReceived:   t.filesReceived,
-		BytesReceived:   t.bytesReceived,
-		FilesSent:       t.filesSent,
-		BytesSent:       t.bytesSent,
-		ActiveUploads:   activeUploads,
-		ActiveDownloads: activeDownloads,
-		LastFilename:    t.lastFilename,
-		LastDirection:   t.lastDirection,
+		StartedAt:         t.startedAt.Format(time.RFC3339),
+		FilesReceived:     t.filesReceived,
+		BytesReceived:     t.bytesReceived,
+		FilesSent:         t.filesSent,
+		BytesSent:         t.bytesSent,
+		ActiveUploads:     activeUploads,
+		ActiveDownloads:   activeDownloads,
+		IntegrityFailures: t.integrityFailures,
+		LastFilename:      t.lastFilename,
+		LastDirection:     t.lastDirection,
 	}
 	if !t.lastUpdatedAt.IsZero() {
 		stats.LastUpdatedAt = t.lastUpdatedAt.Format(time.RFC3339)

--- a/beamsync/stats_test.go
+++ b/beamsync/stats_test.go
@@ -57,6 +57,7 @@ func TestTransferStatsTrackerRecordsSentFiles(t *testing.T) {
 func TestTransferStatsJSON(t *testing.T) {
 	tracker := newTransferStatsTracker()
 	tracker.recordReceived("file.bin", 42, 0)
+	tracker.recordIntegrityFailure()
 	stats := tracker.recordSent("download.bin", 84, 0)
 	raw := transferStatsJSON(stats)
 
@@ -66,5 +67,8 @@ func TestTransferStatsJSON(t *testing.T) {
 	}
 	if decoded.FilesReceived != 1 || decoded.BytesReceived != 42 || decoded.FilesSent != 1 || decoded.BytesSent != 84 {
 		t.Fatalf("decoded stats = %+v", decoded)
+	}
+	if decoded.IntegrityFailures != 1 {
+		t.Fatalf("integrity failures = %d, want 1", decoded.IntegrityFailures)
 	}
 }


### PR DESCRIPTION
## Summary
- Add optional `X-BeamSync-File-SHA256` validation for regular multipart `/upload` requests
- Hash large uploads while streaming to disk and validate small buffered uploads before queueing writes
- Reject mismatches with `400 integrity-mismatch`, avoid keeping corrupted files, and record `integrityFailures` in transfer stats
- Cover matching and mismatched SHA-256 upload flows plus stats JSON output

Fixes #61

## Validation
- `git diff --check`
- `go test -run 'TestUploadWith(Matching|Mismatched)SHA256Header|TestTransferStatsJSON' -count=1 -v` in `beamsync` (passes with Go 1.25.5)
- `go test ./...` in `beamsync` reaches the existing suite but local Windows profile fails pre-existing TLS config tests because `C:\Users\Garima Varshney\.config` exists as a file