### PR TITLE
fix: rate limit resumable upload endpoints

### DIFF
--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -1210,8 +1210,8 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		w.Write([]byte("✅ Upload Complete"))
 	})))
 
-	mux.HandleFunc("/upload/resumable", tokenMiddleware(token, handleResumableUpload(uploadDir, state, emit)))
-	mux.HandleFunc("/upload-status/", tokenMiddleware(token, handleResumableUploadStatus(uploadDir)))
+	mux.HandleFunc("/upload/resumable", rateLimitMiddleware(uploadLimiter, httpServer.settings, tokenMiddleware(token, handleResumableUpload(uploadDir, state, emit))))
+	mux.HandleFunc("/upload-status/", rateLimitMiddleware(uploadLimiter, httpServer.settings, tokenMiddleware(token, handleResumableUploadStatus(uploadDir))))
 
 	portInt, listener, err := FindAvailablePort(startPort, 2, 50)
 	if err != nil {

--- a/beamsync/server_test.go
+++ b/beamsync/server_test.go
@@ -436,6 +436,67 @@ func TestUploadWithoutFileReturnsBadRequest(t *testing.T) {
 	}
 }
 
+func TestResumableEndpointsAreRateLimited(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantBefore int
+	}{
+		{
+			name:       "resumable upload",
+			method:     http.MethodPut,
+			path:       "/upload/resumable",
+			wantBefore: http.StatusBadRequest,
+		},
+		{
+			name:       "upload status",
+			method:     http.MethodGet,
+			path:       "/upload-status/test-upload-id",
+			wantBefore: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, baseURL, token, _, _ := startServerForTest(t)
+			defer server.Shutdown()
+
+			target := baseURL + tc.path + "?token=" + token
+			for i := 0; i < 12; i++ {
+				req, err := http.NewRequest(tc.method, target, nil)
+				if err != nil {
+					t.Fatalf("create request %d: %v", i+1, err)
+				}
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("%s %s request %d: %v", tc.method, tc.path, i+1, err)
+				}
+				resp.Body.Close()
+				if resp.StatusCode != tc.wantBefore {
+					t.Fatalf("request %d status = %d, want %d before rate limit", i+1, resp.StatusCode, tc.wantBefore)
+				}
+			}
+
+			req, err := http.NewRequest(tc.method, target, nil)
+			if err != nil {
+				t.Fatalf("create rate-limited request: %v", err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("%s %s rate-limited request: %v", tc.method, tc.path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusTooManyRequests {
+				t.Fatalf("rate-limited status = %d, want %d", resp.StatusCode, http.StatusTooManyRequests)
+			}
+			if got := resp.Header.Get("Retry-After"); got == "" {
+				t.Fatal("rate-limited response should include Retry-After")
+			}
+		})
+	}
+}
+
 func TestUploadWithFileSavesToDiskAndEmitsEvents(t *testing.T) {
 	server, baseURL, token, events, uploadDir := startServerForTest(t)
 	defer server.Shutdown()


### PR DESCRIPTION
## Summary
- apply the existing upload rate limiter to `/upload/resumable`
- apply the same limiter to `/upload-status/`
- add a regression test proving both resumable endpoints return 429 after the upload limit is exceeded

## Validation
- git diff --check

Note: Go tooling is not installed in this environment (`gofmt`/`go` are unavailable on PATH), so I could not run `gofmt` or `go test` locally.

Closes #51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate limiting is now enforced on resumable upload endpoints. Requests exceeding the configured limit will receive a 429 (Too Many Requests) response.

* **Tests**
  * Added tests to verify rate limiting behavior on resumable upload endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->