### PR TITLE
fix: avoid preallocating large buffers for small uploads

### DIFF
--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -16,6 +16,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -427,6 +428,25 @@ const writeWorkerCount = 3
 const largeFileThreshold = 64 * 1024 * 1024 // 64 MB
 
 const uploadIntegrityHeader = "X-BeamSync-File-SHA256"
+
+func uploadBufferInitialCapacity(filename string, fileSizes map[string]int64, partHeader textproto.MIMEHeader, requestContentLength int64) int {
+	if size, ok := fileSizes[filename]; ok && size > 0 {
+		if size < largeFileThreshold {
+			return int(size)
+		}
+		return largeFileThreshold
+	}
+	if cl, _ := strconv.ParseInt(partHeader.Get("Content-Length"), 10, 64); cl > 0 {
+		if cl < largeFileThreshold {
+			return int(cl)
+		}
+		return largeFileThreshold
+	}
+	if requestContentLength > 0 && requestContentLength < largeFileThreshold {
+		return int(requestContentLength)
+	}
+	return 0
+}
 
 func sha256Hex(data []byte) string {
 	sum := sha256.Sum256(data)
@@ -1031,7 +1051,9 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 
 			// Read up to largeFileThreshold bytes to determine dispatch strategy.
 			var buf bytes.Buffer
-			buf.Grow(largeFileThreshold)
+			if initialCapacity := uploadBufferInitialCapacity(filename, fileSizes, part.Header, r.ContentLength); initialCapacity > 0 {
+				buf.Grow(initialCapacity)
+			}
 			readLimit := int64(largeFileThreshold)
 			n, readErr := io.CopyN(&buf, part, readLimit)
 

--- a/beamsync/server_test.go
+++ b/beamsync/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -116,6 +117,48 @@ func TestSetCORSHeaders(t *testing.T) {
 	}
 	if got := rec.Header().Get("Access-Control-Allow-Headers"); got != "Content-Type" {
 		t.Fatalf("Allow-Headers = %q", got)
+	}
+}
+
+func TestUploadBufferInitialCapacityUsesSmallManifestSize(t *testing.T) {
+	got := uploadBufferInitialCapacity(
+		"tiny.txt",
+		map[string]int64{"tiny.txt": 1024},
+		textproto.MIMEHeader{},
+		largeFileThreshold+1024,
+	)
+
+	if got != 1024 {
+		t.Fatalf("initial capacity = %d, want manifest size 1024", got)
+	}
+}
+
+func TestUploadBufferInitialCapacityCapsLargeManifestAtThreshold(t *testing.T) {
+	got := uploadBufferInitialCapacity(
+		"movie.mp4",
+		map[string]int64{"movie.mp4": largeFileThreshold + 1},
+		textproto.MIMEHeader{},
+		0,
+	)
+
+	if got != largeFileThreshold {
+		t.Fatalf("initial capacity = %d, want largeFileThreshold", got)
+	}
+}
+
+func TestUploadBufferInitialCapacityFallsBackToRequestLength(t *testing.T) {
+	got := uploadBufferInitialCapacity("unknown.txt", nil, textproto.MIMEHeader{}, 4096)
+
+	if got != 4096 {
+		t.Fatalf("initial capacity = %d, want request content length 4096", got)
+	}
+}
+
+func TestUploadBufferInitialCapacityAvoidsUnknownLargePreallocation(t *testing.T) {
+	got := uploadBufferInitialCapacity("unknown.bin", nil, textproto.MIMEHeader{}, largeFileThreshold+1024)
+
+	if got != 0 {
+		t.Fatalf("initial capacity = %d, want 0 for unknown large upload", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the unconditional 64MB `bytes.Buffer` preallocation for regular uploads
- size the initial upload buffer from manifest, multipart, or request size hints when available
- keep large uploads capped at the existing 64MB dispatch threshold and let unknown-size uploads grow naturally
- add focused tests for small manifest sizing, large-size capping, request-length fallback, and unknown large uploads

## Validation
- git diff --check

Note: Go tooling is not installed in this environment (`go`/`gofmt` are unavailable on PATH), so I could not run local Go tests or formatting. GitHub CI should run the Go checks.

Closes #50
