### PR TITLE
docs: add missing ToC links for Network Requirements and Developer API sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 - [Installation](#installation)
 - [Building from Source](#building-from-source)
 - [Usage Guide](#usage-guide)
+- [Network Requirements & Connectivity Notes](#network-requirements--connectivity-notes)
+- [Developer API](#developer-api)
 - [API Documentation](API.md)
 - [Security & Privacy](#security--privacy)
 - [License](#license)


### PR DESCRIPTION
Issue #43 asked for a Table of Contents in the README. While reviewing it, I found the ToC already existed but was missing links to two sections that were added later — "Network Requirements & Connectivity Notes" and "Developer API". This PR adds those two missing entries so the ToC fully covers all current sections.

Relates to #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README table of contents with two new sections: "Network Requirements & Connectivity Notes" and "Developer API" for improved navigation and documentation organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->