### PR TITLE
move rate limiter pruning to background

### DIFF
--- a/beamsync/rate_limiter_test.go
+++ b/beamsync/rate_limiter_test.go
@@ -71,6 +71,32 @@ func TestClientRateLimiterEvictsOldestClientWhenFull(t *testing.T) {
 	}
 }
 
+func TestClientRateLimiterPrunesExpiredClients(t *testing.T) {
+	now := time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC)
+	limiter := newClientRateLimiter(2, time.Minute)
+	limiter.now = func() time.Time { return now }
+
+	limiter.clients["10.0.0.1"] = &rateLimitState{
+		windowStart: now.Add(-3 * time.Minute),
+		count:       1,
+		lastSeen:    now.Add(-3 * time.Minute),
+	}
+	limiter.clients["10.0.0.2"] = &rateLimitState{
+		windowStart: now.Add(-30 * time.Second),
+		count:       1,
+		lastSeen:    now.Add(-30 * time.Second),
+	}
+
+	limiter.prune(now)
+
+	if _, ok := limiter.clients["10.0.0.1"]; ok {
+		t.Fatal("stale client should be pruned")
+	}
+	if _, ok := limiter.clients["10.0.0.2"]; !ok {
+		t.Fatal("recent client should remain")
+	}
+}
+
 func TestRateLimitMiddlewareReturns429(t *testing.T) {
 	now := time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC)
 	limiter := newClientRateLimiter(1, time.Minute)

--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -158,13 +158,57 @@ type clientRateLimiter struct {
 	now        func() time.Time
 }
 
+const clientRateLimiterPruneInterval = 2 * time.Minute
+
+var clientRateLimiterPruner = struct {
+	once     sync.Once
+	mu       sync.Mutex
+	limiters map[*clientRateLimiter]struct{}
+}{
+	limiters: make(map[*clientRateLimiter]struct{}),
+}
+
 func newClientRateLimiter(limit int, window time.Duration) *clientRateLimiter {
-	return &clientRateLimiter{
+	limiter := &clientRateLimiter{
 		limit:      limit,
 		window:     window,
 		maxClients: 4096,
 		clients:    make(map[string]*rateLimitState),
 		now:        time.Now,
+	}
+	registerClientRateLimiter(limiter)
+	return limiter
+}
+
+func registerClientRateLimiter(limiter *clientRateLimiter) {
+	if limiter == nil {
+		return
+	}
+
+	clientRateLimiterPruner.mu.Lock()
+	clientRateLimiterPruner.limiters[limiter] = struct{}{}
+	clientRateLimiterPruner.mu.Unlock()
+
+	clientRateLimiterPruner.once.Do(func() {
+		go runClientRateLimiterPruner()
+	})
+}
+
+func runClientRateLimiterPruner() {
+	ticker := time.NewTicker(clientRateLimiterPruneInterval)
+	defer ticker.Stop()
+
+	for now := range ticker.C {
+		clientRateLimiterPruner.mu.Lock()
+		limiters := make([]*clientRateLimiter, 0, len(clientRateLimiterPruner.limiters))
+		for limiter := range clientRateLimiterPruner.limiters {
+			limiters = append(limiters, limiter)
+		}
+		clientRateLimiterPruner.mu.Unlock()
+
+		for _, limiter := range limiters {
+			limiter.prune(now)
+		}
 	}
 }
 
@@ -177,8 +221,6 @@ func (l *clientRateLimiter) allow(client string) rateLimitDecision {
 	resetAt := now.Add(l.window)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-
-	l.prune(now)
 
 	state, ok := l.clients[client]
 	if !ok || now.Sub(state.windowStart) >= l.window {


### PR DESCRIPTION
Move rate limiter pruning out of the request path so rate-limited requests only do the fast lookup/update work.

- Issue: #55
- Added a shared background pruning loop for all client rate limiters
- Kept the existing prune logic deterministic and covered it with a regression test

Validation:
- `go test ./...`
- `git diff --check`
