### PR TITLE
feat: add ephemeral HMAC-bound transfer tokens

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,7 +43,7 @@ To prevent copied URLs from granting another device access, BeamSync uses short-
 ```bash
 curl -X GET "http://192.168.1.50:3000/?token=<qr-bootstrap-token>"
 # With BEAMSYNC_ENABLE_TLS=true:
-curl -k -X GET "https://192.168.1.50:3000/"
+curl -k -X GET "https://192.168.1.50:3000/?token=<qr-bootstrap-token>"
 ```
 
 ---

--- a/API.md
+++ b/API.md
@@ -10,15 +10,17 @@ Set `BEAMSYNC_ENABLE_TLS=true` before launching BeamSync to serve the same endpo
 
 ## 🔒 Authentication & Token Scheme
 
-To prevent unauthorized devices on the local network from sending or downloading files, BeamSync uses a **Session Token Authentication Scheme**:
+To prevent copied URLs from granting another device access, BeamSync uses short-lived HMAC credentials:
 
-1. **Token Generation:** When the server starts, it generates a cryptographically secure 16-byte (32-character hexadecimal) session token using Go's `crypto/rand` (`generateToken()`).
-2. **Access Control:** All API endpoints (except the UI home page and logo asset) are protected by a token-validation middleware (`tokenMiddleware`).
-3. **Usage:** Clients must supply the session token as a query parameter in every request:
+1. **QR bootstrap:** Receiver and sender QR URLs contain a five-minute, single-use bootstrap credential. Loading the URL exchanges it for a session token bound to the connecting client IP.
+2. **HMAC binding:** Tokens are signed with a per-server secret over the server session, TLS certificate fingerprint (or the explicit plaintext-HTTP context), client IP, scope, expiration, and a random nonce.
+3. **Expiry and renewal:** Credentials expire after five minutes. Successful heartbeats return a replacement session token in the `X-BeamSync-Token` response header, which the bundled web clients adopt automatically.
+4. **Transfer scope:** Download URLs use client-bound, single-use transfer tokens. Replaying a completed download URL returns `403 Forbidden`.
+5. **Usage:** Clients supply their current credential as a query parameter:
    ```http
-   ?token=your_32_character_hex_session_token
+   ?token=your_hmac_credential
    ```
-4. **Validation:** If the token is missing or incorrect, the server immediately rejects the request with a `403 Forbidden` response.
+6. **Validation:** Missing, expired, replayed, wrong-scope, wrong-client, or tampered credentials are rejected with `403 Forbidden`. Token responses use `Cache-Control: no-store`.
 
 ---
 
@@ -27,18 +29,19 @@ To prevent unauthorized devices on the local network from sending or downloading
 ### 1. Serve Upload UI
 *   **URL:** `/`
 *   **HTTP Method:** `GET`
-*   **Authentication:** None (Required to load the page that retrieves the token)
-*   **Query Parameters:** None
+*   **Authentication:** Receiver and sender modes require the single-use QR bootstrap token.
+*   **Query Parameters:**
+    *   `token`: Five-minute QR bootstrap credential.
 *   **Request Body:** None
 *   **Response Format:** `text/html`
 *   **Status Codes:**
     *   `200 OK` — Success, UI page loaded.
     *   `500 Internal Server Error` — UI asset failed to load.
-*   **Description:** Serves the responsive mobile upload page (`ui/upload.html`). The server dynamically injects the generated session token into the page template placeholder (`{{TOKEN}}`) so the mobile browser can authenticate subsequent API calls. Loading this page automatically registers a connection heartbeat.
+*   **Description:** Serves the responsive mobile page and injects an IP-bound five-minute session token into `{{TOKEN}}`. The bootstrap credential is consumed during this exchange. Loading the page automatically registers a connection heartbeat.
 
 #### Example Curl:
 ```bash
-curl -X GET "http://192.168.1.50:3000/"
+curl -X GET "http://192.168.1.50:3000/?token=<qr-bootstrap-token>"
 # With BEAMSYNC_ENABLE_TLS=true:
 curl -k -X GET "https://192.168.1.50:3000/"
 ```
@@ -53,11 +56,14 @@ curl -k -X GET "https://192.168.1.50:3000/"
     *   `token` (string, required): Session authentication token.
 *   **Request Body:** None
 *   **Response Format:** Empty response body
+*   **Response Headers:**
+    *   `X-BeamSync-Token`: Replacement IP-bound session token with a fresh five-minute lifetime.
+    *   `Cache-Control: no-store`
 *   **Status Codes:**
     *   `200 OK` — Heartbeat successfully registered.
     *   `403 Forbidden` — Missing or invalid token.
     *   `405 Method Not Allowed` — HTTP method was not `POST`.
-*   **Description:** Keeps the connection alive. The mobile browser pings this endpoint every 5 seconds. If the server's watchdog goroutine does not detect a heartbeat or active file transfer write within 15 seconds, it emits a `device_disconnected` event to the desktop app.
+*   **Description:** Keeps the connection alive and renews the short-lived session. The mobile browser pings every 5 seconds and adopts `X-BeamSync-Token`. If the watchdog does not detect a heartbeat or active file transfer within 15 seconds, it emits `device_disconnected`.
 
 #### Example Curl:
 ```bash
@@ -71,7 +77,7 @@ curl -X POST "http://192.168.1.50:3000/heartbeat?token=8a3ef2e987c654ab23f0de1a8
 *   **HTTP Method:** `POST`
 *   **Authentication:** Token Query Parameter (`?token=...`)
 *   **Query Parameters:**
-    *   `token` (string, required): Session authentication token.
+    *   `token` (string, required): Current client-bound session token.
 *   **Request Body:** `application/json`
     ```json
     {
@@ -148,9 +154,9 @@ curl -X POST "http://192.168.1.50:3000/upload?token=8a3ef2e987c654ab23f0de1a87e5
 ### 5. Download File Stream
 *   **URL:** `/download` (Single-file transfer) or `/download/:index` (Multi-file transfer, e.g. `/download/0`, `/download/1`)
 *   **HTTP Method:** `GET`
-*   **Authentication:** Token Query Parameter (`?token=...`)
+*   **Authentication:** Single-use, client-bound transfer token generated into the sender page.
 *   **Query Parameters:**
-    *   `token` (string, required): Session authentication token.
+    *   `token` (string, required): Single-use transfer token.
 *   **Request Body:** None
 *   **Response Headers:**
     *   `Content-Disposition: attachment; filename="filename.ext"`
@@ -163,7 +169,7 @@ curl -X POST "http://192.168.1.50:3000/upload?token=8a3ef2e987c654ab23f0de1a87e5
     *   `403 Forbidden` — Missing or invalid token.
     *   `404 Not Found` — File not found or index out of range.
     *   `500 Internal Server Error` — Failed to open or read file on disk.
-*   **Description:** Streams files from the desktop sender to a remote receiver. Emits progressive `download_progress` events to the desktop UI.
+*   **Description:** Streams one file from the desktop sender and consumes the URL token before the handler runs. Replaying or copying the URL to another client is rejected. Emits progressive `download_progress` events to the desktop UI.
 
 #### Example Curl:
 ```bash

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ For developers, contributors, and security auditors who want to understand the u
 
 - **Local-only** — All transfers happen over your LAN. No external servers are contacted.
 - **Optional HTTPS** — Set `BEAMSYNC_ENABLE_TLS=true` before launching BeamSync to serve receiver and sender pages over HTTPS with a persisted ECDSA local certificate in `~/.config/beamsync/`.
+- **Ephemeral credentials** — HMAC-signed sessions expire after five minutes, bind to the connecting client and TLS context, renew through heartbeats, and use single-use links for downloads.
 - **Zero data collection** — BeamSync does not store, transmit, or analyze your files beyond the direct LAN transfer.
 - **Open source** — The entire codebase is available for audit.
 

--- a/beamsync/auth_tokens.go
+++ b/beamsync/auth_tokens.go
@@ -1,0 +1,170 @@
+package beamsync
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const defaultTokenTTL = 5 * time.Minute
+
+type tokenScope string
+
+const (
+	tokenScopeBootstrap tokenScope = "bootstrap"
+	tokenScopeSession   tokenScope = "session"
+	tokenScopeTransfer  tokenScope = "transfer"
+)
+
+var (
+	errInvalidToken = errors.New("invalid token")
+	errExpiredToken = errors.New("expired token")
+	errUsedToken    = errors.New("token use limit exceeded")
+	errWrongClient  = errors.New("token is bound to another client")
+)
+
+type tokenRecord struct {
+	Value            string
+	CreatedAt        time.Time
+	ExpiresAt        time.Time
+	MaxUses          int
+	UseCount         int
+	BoundFingerprint string
+	BoundClientIP    string
+	Scope            tokenScope
+	Nonce            string
+}
+
+type tokenStore struct {
+	mu          sync.Mutex
+	secret      []byte
+	sessionID   string
+	fingerprint string
+	ttl         time.Duration
+	now         func() time.Time
+	tokens      map[string]*tokenRecord
+}
+
+func newTokenStore(fingerprint string) (*tokenStore, error) {
+	secret, err := randomBytes(32)
+	if err != nil {
+		return nil, fmt.Errorf("generate token secret: %w", err)
+	}
+	sessionIDBytes, err := randomBytes(16)
+	if err != nil {
+		return nil, fmt.Errorf("generate token session ID: %w", err)
+	}
+	return &tokenStore{
+		secret:      secret,
+		sessionID:   hex.EncodeToString(sessionIDBytes),
+		fingerprint: fingerprint,
+		ttl:         defaultTokenTTL,
+		now:         time.Now,
+		tokens:      make(map[string]*tokenRecord),
+	}, nil
+}
+
+func randomBytes(size int) ([]byte, error) {
+	value := make([]byte, size)
+	if _, err := rand.Read(value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func (s *tokenStore) issue(scope tokenScope, maxUses int, clientIP string) (string, error) {
+	nonceBytes, err := randomBytes(16)
+	if err != nil {
+		return "", fmt.Errorf("generate token nonce: %w", err)
+	}
+
+	now := s.now()
+	record := &tokenRecord{
+		CreatedAt:        now,
+		ExpiresAt:        now.Add(s.ttl),
+		MaxUses:          maxUses,
+		BoundFingerprint: s.fingerprint,
+		BoundClientIP:    clientIP,
+		Scope:            scope,
+		Nonce:            hex.EncodeToString(nonceBytes),
+	}
+	record.Value = s.sign(record)
+
+	s.mu.Lock()
+	s.tokens[record.Value] = record
+	s.mu.Unlock()
+	return record.Value, nil
+}
+
+func (s *tokenStore) sign(record *tokenRecord) string {
+	payload := fmt.Sprintf("%s|%s|%s|%s|%d|%s",
+		s.sessionID,
+		record.BoundFingerprint,
+		record.BoundClientIP,
+		record.Scope,
+		record.ExpiresAt.Unix(),
+		record.Nonce,
+	)
+	mac := hmac.New(sha256.New, s.secret)
+	_, _ = mac.Write([]byte(payload))
+	return hex.EncodeToString(mac.Sum(nil)) + "." + record.Nonce
+}
+
+func (s *tokenStore) validate(value, clientIP string, scope tokenScope, consume bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.tokens[value]
+	if !ok || record.Scope != scope || !hmac.Equal([]byte(value), []byte(s.sign(record))) {
+		return errInvalidToken
+	}
+	if !s.now().Before(record.ExpiresAt) {
+		delete(s.tokens, value)
+		return errExpiredToken
+	}
+	if record.BoundFingerprint != s.fingerprint {
+		return errInvalidToken
+	}
+	if record.BoundClientIP != "" && record.BoundClientIP != clientIP {
+		return errWrongClient
+	}
+	if record.MaxUses > 0 && record.UseCount >= record.MaxUses {
+		return errUsedToken
+	}
+	if consume {
+		record.UseCount++
+	}
+	return nil
+}
+
+func (s *tokenStore) cleanupExpired() {
+	now := s.now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for value, record := range s.tokens {
+		if !now.Before(record.ExpiresAt) || (record.MaxUses > 0 && record.UseCount >= record.MaxUses) {
+			delete(s.tokens, value)
+		}
+	}
+}
+
+func (s *tokenStore) startCleanup(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.cleanupExpired()
+			}
+		}
+	}()
+}

--- a/beamsync/auth_tokens_test.go
+++ b/beamsync/auth_tokens_test.go
@@ -1,0 +1,78 @@
+package beamsync
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTokenStoreForTest(t *testing.T) *tokenStore {
+	t.Helper()
+	store, err := newTokenStore("test-fingerprint")
+	if err != nil {
+		t.Fatalf("newTokenStore: %v", err)
+	}
+	return store
+}
+
+func TestTokenStoreBindsTokensToClientAndScope(t *testing.T) {
+	store := newTokenStoreForTest(t)
+	token, err := store.issue(tokenScopeSession, 0, "192.0.2.10")
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+
+	if err := store.validate(token, "192.0.2.10", tokenScopeSession, false); err != nil {
+		t.Fatalf("validate bound token: %v", err)
+	}
+	if err := store.validate(token, "192.0.2.11", tokenScopeSession, false); !errors.Is(err, errWrongClient) {
+		t.Fatalf("wrong-client error = %v, want %v", err, errWrongClient)
+	}
+	if err := store.validate(token, "192.0.2.10", tokenScopeTransfer, false); !errors.Is(err, errInvalidToken) {
+		t.Fatalf("wrong-scope error = %v, want %v", err, errInvalidToken)
+	}
+}
+
+func TestTokenStoreExpiresTokens(t *testing.T) {
+	store := newTokenStoreForTest(t)
+	now := time.Unix(1_700_000_000, 0)
+	store.now = func() time.Time { return now }
+	store.ttl = time.Minute
+	token, err := store.issue(tokenScopeSession, 0, "192.0.2.10")
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+
+	now = now.Add(time.Minute)
+	if err := store.validate(token, "192.0.2.10", tokenScopeSession, false); !errors.Is(err, errExpiredToken) {
+		t.Fatalf("expired-token error = %v, want %v", err, errExpiredToken)
+	}
+}
+
+func TestTokenStoreEnforcesSingleUse(t *testing.T) {
+	store := newTokenStoreForTest(t)
+	token, err := store.issue(tokenScopeTransfer, 1, "192.0.2.10")
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+
+	if err := store.validate(token, "192.0.2.10", tokenScopeTransfer, true); err != nil {
+		t.Fatalf("first use: %v", err)
+	}
+	if err := store.validate(token, "192.0.2.10", tokenScopeTransfer, true); !errors.Is(err, errUsedToken) {
+		t.Fatalf("replay error = %v, want %v", err, errUsedToken)
+	}
+}
+
+func TestTokenStoreRejectsTampering(t *testing.T) {
+	store := newTokenStoreForTest(t)
+	token, err := store.issue(tokenScopeSession, 0, "192.0.2.10")
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+
+	tampered := "0" + token[1:]
+	if err := store.validate(tampered, "192.0.2.10", tokenScopeSession, false); !errors.Is(err, errInvalidToken) {
+		t.Fatalf("tampered-token error = %v, want %v", err, errInvalidToken)
+	}
+}

--- a/beamsync/auth_tokens_test.go
+++ b/beamsync/auth_tokens_test.go
@@ -71,7 +71,11 @@ func TestTokenStoreRejectsTampering(t *testing.T) {
 		t.Fatalf("issue token: %v", err)
 	}
 
-	tampered := "0" + token[1:]
+	newFirstChar := byte('0')
+	if token[0] == '0' {
+		newFirstChar = '1'
+	}
+	tampered := string(newFirstChar) + token[1:]
 	if err := store.validate(tampered, "192.0.2.10", tokenScopeSession, false); !errors.Is(err, errInvalidToken) {
 		t.Fatalf("tampered-token error = %v, want %v", err, errInvalidToken)
 	}

--- a/beamsync/server.go
+++ b/beamsync/server.go
@@ -269,6 +269,7 @@ type HTTPServer struct {
 	settings         *TransferSettings
 	history          *TransferHistory
 	stats            *transferStatsTracker
+	tokens           *tokenStore
 }
 
 // RespondToTransfer approves or rejects a pending transfer by ID.
@@ -572,8 +573,8 @@ func processManifest(r io.Reader) (map[string]int64, error) {
 	return fileSizes, nil
 }
 
-// generateToken creates a 16-byte (32 hex char) crypto-random session token.
-func generateToken() string {
+// generateID creates a crypto-random identifier for non-authentication records.
+func generateID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		// Fallback: timestamp-based (unlikely but safe)
@@ -582,15 +583,16 @@ func generateToken() string {
 	return hex.EncodeToString(b)
 }
 
-// validateToken middleware — returns 403 if the token query-param doesn't match.
-// Exempt routes: "/" (serves UI page).
-func tokenMiddleware(token string, next http.HandlerFunc) http.HandlerFunc {
+// tokenMiddleware rejects credentials that are expired, replayed, wrong-scope,
+// tampered, or bound to a different client IP.
+func tokenMiddleware(tokens *tokenStore, scope tokenScope, consume bool, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		if got := r.URL.Query().Get("token"); got != token {
+		if err := tokens.validate(r.URL.Query().Get("token"), clientIP(r), scope, consume); err != nil {
+			w.Header().Set("Cache-Control", "no-store")
 			http.Error(w, "403 Forbidden: invalid token", http.StatusForbidden)
 			return
 		}
@@ -748,11 +750,26 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 	}
 	fmt.Printf("📁 Upload directory: %s\n", uploadDir)
 
-	token := generateToken()
+	fingerprint, err := serverTLSFingerprint()
+	if err != nil {
+		fmt.Println("Failed to establish token fingerprint:", err)
+		return nil, "", ""
+	}
+	tokens, err := newTokenStore(fingerprint)
+	if err != nil {
+		fmt.Println("Failed to initialize token store:", err)
+		return nil, "", ""
+	}
+	token, err := tokens.issue(tokenScopeBootstrap, 1, "")
+	if err != nil {
+		fmt.Println("Failed to issue bootstrap token:", err)
+		return nil, "", ""
+	}
 	emit := func(evt, data string) { safeEmit(callback, evt, data) }
 
 	state := &serverState{}
 	ctx, cancel := context.WithCancel(context.Background())
+	tokens.startCleanup(ctx)
 
 	startWatchdog(ctx, state, emit)
 
@@ -763,6 +780,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		settings:         &settingsCopy,
 		history:          NewTransferHistory(defaultTransferHistoryLimit),
 		stats:            newTransferStatsTracker(),
+		tokens:           tokens,
 	}
 
 	mux := http.NewServeMux()
@@ -772,7 +790,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 	uploadLimiter := newClientRateLimiter(12, time.Minute)
 
 	// ── Heartbeat ────────────────────────────────────────────────────────────
-	mux.HandleFunc("/heartbeat", rateLimitMiddleware(heartbeatLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/heartbeat", rateLimitMiddleware(heartbeatLimiter, httpServer.settings, tokenMiddleware(tokens, tokenScopeSession, false, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -783,13 +801,24 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 			emit("device_connected", "Android Device")
 			fmt.Println("💚 Device Connected!")
 		}
+		refreshedToken, err := tokens.issue(tokenScopeSession, 0, clientIP(r))
+		if err != nil {
+			http.Error(w, "Failed to renew session", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("X-BeamSync-Token", refreshedToken)
+		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusOK)
 	})))
 
-	// ── Serve UI (no token required — this IS the page that shows the token) ─
+	// ── Exchange the one-use QR credential for a client-bound session ───────
 	mux.HandleFunc("/", rateLimitMiddleware(pageLimiter, httpServer.settings, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/" {
 			http.NotFound(w, r)
+			return
+		}
+		if err := tokens.validate(r.URL.Query().Get("token"), clientIP(r), tokenScopeBootstrap, true); err != nil {
+			http.Error(w, "403 Forbidden: reconnect by scanning the current QR code", http.StatusForbidden)
 			return
 		}
 		fmt.Println("🌐 GET / - Serving upload UI")
@@ -799,8 +828,13 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 			http.Error(w, "UI Load Error", http.StatusInternalServerError)
 			return
 		}
-		// Inject token so the upload page knows it
-		html := strings.Replace(string(content), "{{TOKEN}}", token, 1)
+		sessionToken, err := tokens.issue(tokenScopeSession, 0, clientIP(r))
+		if err != nil {
+			http.Error(w, "Failed to create session", http.StatusInternalServerError)
+			return
+		}
+		html := strings.Replace(string(content), "{{TOKEN}}", sessionToken, 1)
+		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Content-Type", "text/html")
 		w.Write([]byte(html))
 
@@ -825,7 +859,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		w.Write(content)
 	}))
 
-	mux.HandleFunc("/stats", tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/stats", tokenMiddleware(tokens, tokenScopeSession, false, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -837,7 +871,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 	}))
 
 	// ── Request Transfer (ask before accepting) ──────────────────────────────
-	mux.HandleFunc("/request-transfer", rateLimitMiddleware(transferLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/request-transfer", rateLimitMiddleware(transferLimiter, httpServer.settings, tokenMiddleware(tokens, tokenScopeSession, false, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -905,7 +939,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		}
 
 		// ── ask_first: emit event and wait for user response ──────────────────
-		id := generateToken()
+		id := generateID()
 		sizeMB := fmt.Sprintf("%.2f MB", float64(req.SizeBytes)/1024/1024)
 
 		pt := &PendingTransfer{
@@ -952,7 +986,7 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 	})))
 
 	// ── Upload ────────────────────────────────────────────────────────────────
-	mux.HandleFunc("/upload", rateLimitMiddleware(uploadLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/upload", rateLimitMiddleware(uploadLimiter, httpServer.settings, tokenMiddleware(tokens, tokenScopeSession, false, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("📤 POST /upload - Upload started")
 
 		defer func() {
@@ -1232,8 +1266,8 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 		w.Write([]byte("✅ Upload Complete"))
 	})))
 
-	mux.HandleFunc("/upload/resumable", rateLimitMiddleware(uploadLimiter, httpServer.settings, tokenMiddleware(token, handleResumableUpload(uploadDir, state, emit))))
-	mux.HandleFunc("/upload-status/", rateLimitMiddleware(uploadLimiter, httpServer.settings, tokenMiddleware(token, handleResumableUploadStatus(uploadDir))))
+	mux.HandleFunc("/upload/resumable", rateLimitMiddleware(uploadLimiter, httpServer.settings, tokenMiddleware(tokens, tokenScopeSession, false, handleResumableUpload(uploadDir, state, emit))))
+	mux.HandleFunc("/upload-status/", rateLimitMiddleware(uploadLimiter, httpServer.settings, tokenMiddleware(tokens, tokenScopeSession, false, handleResumableUploadStatus(uploadDir))))
 
 	portInt, listener, err := FindAvailablePort(startPort, 2, 50)
 	if err != nil {
@@ -1293,17 +1327,33 @@ func StartServer(uploadDir string, startPort int, settings TransferSettings, cal
 }
 
 // StartSender starts the file-sender HTTP server.
-// Returns (server handle, port string, session token).
+// Returns (server handle, port string, single-use bootstrap token).
 func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, string, string) {
-	token := generateToken()
+	fingerprint, err := serverTLSFingerprint()
+	if err != nil {
+		fmt.Println("Failed to establish token fingerprint:", err)
+		return nil, "", ""
+	}
+	tokens, err := newTokenStore(fingerprint)
+	if err != nil {
+		fmt.Println("Failed to initialize token store:", err)
+		return nil, "", ""
+	}
+	token, err := tokens.issue(tokenScopeBootstrap, 1, "")
+	if err != nil {
+		fmt.Println("Failed to issue sender bootstrap token:", err)
+		return nil, "", ""
+	}
 	emit := func(evt, data string) { safeEmit(callback, evt, data) }
 
 	state := &serverState{}
 	ctx, cancel := context.WithCancel(context.Background())
+	tokens.startCleanup(ctx)
 	httpServer := &HTTPServer{
 		cancel:  cancel,
 		history: NewTransferHistory(defaultTransferHistoryLimit),
 		stats:   newTransferStatsTracker(),
+		tokens:  tokens,
 	}
 
 	// Sender also gets a watchdog
@@ -1315,7 +1365,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 	downloadLimiter := newClientRateLimiter(30, time.Minute)
 
 	// ── Heartbeat ─────────────────────────────────────────────────────────────
-	mux.HandleFunc("/heartbeat", rateLimitMiddleware(heartbeatLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/heartbeat", rateLimitMiddleware(heartbeatLimiter, httpServer.settings, tokenMiddleware(tokens, tokenScopeSession, false, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -1327,13 +1377,18 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 			emit("device_connected", "Mobile (Downloader)")
 			fmt.Println("💚 Device Connected to Sender!")
 		}
+		refreshedToken, err := tokens.issue(tokenScopeSession, 0, clientIP(r))
+		if err != nil {
+			http.Error(w, "Failed to renew session", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("X-BeamSync-Token", refreshedToken)
 		w.WriteHeader(http.StatusOK)
 	})))
 
-	// ── Serve files (no token on / — mobile opens the download page directly) ─
-	// The generated download URL embedded in the QR already carries the token.
+	// ── Exchange the one-use QR credential for a client-bound session ───────
 
-	buildFileBlock := func(filePaths []string) string {
+	buildFileBlock := func(filePaths []string, boundClientIP string) (string, error) {
 		fmtSize := func(sz int64) string {
 			switch {
 			case sz >= 1073741824:
@@ -1372,7 +1427,11 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 			if info, err := os.Stat(filePaths[0]); err == nil {
 				sizeStr = fmtSize(info.Size())
 			}
-			b.WriteString(card(name, sizeStr, "single", fmt.Sprintf("/download?token=%s", token)))
+			transferToken, err := tokens.issue(tokenScopeTransfer, 1, boundClientIP)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(card(name, sizeStr, "single", fmt.Sprintf("/download?token=%s", transferToken)))
 		} else {
 			for i, path := range filePaths {
 				name := filepath.Base(path)
@@ -1381,14 +1440,26 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 					sizeStr = fmtSize(info.Size())
 				}
 				cardID := fmt.Sprintf("multi-%d", i)
-				downloadURL := fmt.Sprintf("/download/%d?token=%s", i, token)
+				transferToken, err := tokens.issue(tokenScopeTransfer, 1, boundClientIP)
+				if err != nil {
+					return "", err
+				}
+				downloadURL := fmt.Sprintf("/download/%d?token=%s", i, transferToken)
 				b.WriteString(card(name, sizeStr, cardID, downloadURL))
 			}
 		}
-		return b.String()
+		return b.String(), nil
 	}
 
 	mux.HandleFunc("/", rateLimitMiddleware(pageLimiter, httpServer.settings, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := tokens.validate(r.URL.Query().Get("token"), clientIP(r), tokenScopeBootstrap, true); err != nil {
+			http.Error(w, "403 Forbidden: reconnect by scanning the current QR code", http.StatusForbidden)
+			return
+		}
 		setCORSHeaders(w)
 		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 		w.Header().Set("Content-Type", "text/html")
@@ -1397,8 +1468,19 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 			http.Error(w, "UI Load Error", http.StatusInternalServerError)
 			return
 		}
-		html := strings.Replace(string(content), "{{FILES}}", buildFileBlock(filePaths), 1)
-		html = strings.Replace(html, "{{TOKEN}}", token, 1)
+		boundClientIP := clientIP(r)
+		fileBlock, err := buildFileBlock(filePaths, boundClientIP)
+		if err != nil {
+			http.Error(w, "Failed to create transfer links", http.StatusInternalServerError)
+			return
+		}
+		sessionToken, err := tokens.issue(tokenScopeSession, 0, boundClientIP)
+		if err != nil {
+			http.Error(w, "Failed to create session", http.StatusInternalServerError)
+			return
+		}
+		html := strings.Replace(string(content), "{{FILES}}", fileBlock, 1)
+		html = strings.Replace(html, "{{TOKEN}}", sessionToken, 1)
 		w.Write([]byte(html))
 	}))
 
@@ -1417,7 +1499,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 	if len(filePaths) == 1 {
 		filePath := filePaths[0]
 		filename := filepath.Base(filePath)
-		mux.HandleFunc("/download", rateLimitMiddleware(downloadLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/download", rateLimitMiddleware(downloadLimiter, httpServer.settings, tokenMiddleware(tokens, tokenScopeTransfer, true, func(w http.ResponseWriter, r *http.Request) {
 			activeDownloads := atomic.AddInt32(&state.uploadingCount, 1)
 			emit("transfer_stats", transferStatsJSON(httpServer.stats.snapshotDownloads(activeDownloads)))
 			defer func() {
@@ -1488,7 +1570,7 @@ func StartSender(filePaths []string, callback EventCallback) (*HTTPServer, strin
 		for i, path := range filePaths {
 			idx := i
 			filePath := path
-			mux.HandleFunc(fmt.Sprintf("/download/%d", idx), rateLimitMiddleware(downloadLimiter, httpServer.settings, tokenMiddleware(token, func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/download/%d", idx), rateLimitMiddleware(downloadLimiter, httpServer.settings, tokenMiddleware(tokens, tokenScopeTransfer, true, func(w http.ResponseWriter, r *http.Request) {
 				realName := filepath.Base(filePath)
 				activeDownloads := atomic.AddInt32(&state.uploadingCount, 1)
 				emit("transfer_stats", transferStatsJSON(httpServer.stats.snapshotDownloads(activeDownloads)))

--- a/beamsync/server_test.go
+++ b/beamsync/server_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 func TestTokenMiddlewareRejectsMissingOrInvalidToken(t *testing.T) {
-	handler := tokenMiddleware("secret-token", func(w http.ResponseWriter, r *http.Request) {
+	store := newTokenStoreForTest(t)
+	handler := tokenMiddleware(store, tokenScopeSession, false, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
@@ -42,11 +43,17 @@ func TestTokenMiddlewareRejectsMissingOrInvalidToken(t *testing.T) {
 }
 
 func TestTokenMiddlewareAllowsValidTokenAndOptions(t *testing.T) {
-	handler := tokenMiddleware("secret-token", func(w http.ResponseWriter, r *http.Request) {
+	store := newTokenStoreForTest(t)
+	token, err := store.issue(tokenScopeSession, 0, "192.0.2.10")
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	handler := tokenMiddleware(store, tokenScopeSession, false, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/upload?token=secret-token", nil)
+	req := httptest.NewRequest(http.MethodPost, "/upload?token="+token, nil)
+	req.RemoteAddr = "192.0.2.10:1234"
 	rec := httptest.NewRecorder()
 	handler(rec, req)
 	if rec.Code != http.StatusAccepted {
@@ -81,8 +88,8 @@ func TestAutoRenamePathFindsNonCollidingName(t *testing.T) {
 	}
 }
 
-func TestGenerateTokenReturnsHexToken(t *testing.T) {
-	token := generateToken()
+func TestGenerateIDReturnsHexValue(t *testing.T) {
+	token := generateID()
 	if len(token) != 32 {
 		t.Fatalf("token length = %d, want 32", len(token))
 	}
@@ -93,12 +100,12 @@ func TestGenerateTokenReturnsHexToken(t *testing.T) {
 	}
 }
 
-func TestGenerateTokenDoesNotCollideInSmallSample(t *testing.T) {
+func TestGenerateIDDoesNotCollideInSmallSample(t *testing.T) {
 	seen := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		token := generateToken()
+		token := generateID()
 		if seen[token] {
-			t.Fatalf("generateToken collision at token %q", token)
+			t.Fatalf("generateID collision at value %q", token)
 		}
 		seen[token] = true
 	}
@@ -411,9 +418,9 @@ func TestStartWriteWorkersProcessesJobsAndIgnoresCreateErrors(t *testing.T) {
 }
 
 func TestStartServerLifecycleRootAndHeartbeat(t *testing.T) {
-	server, baseURL, token, events, _ := startServerForTest(t)
+	server, baseURL, bootstrapToken, events, _ := startRawServerForTest(t)
 
-	resp, err := http.Get(baseURL + "/")
+	resp, err := http.Get(baseURL + "/?token=" + bootstrapToken)
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
@@ -428,8 +435,18 @@ func TestStartServerLifecycleRootAndHeartbeat(t *testing.T) {
 	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
 		t.Fatalf("root Access-Control-Allow-Origin = %q, want *", got)
 	}
-	if !strings.Contains(string(body), token) {
-		t.Fatal("root page did not include session token")
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("root Cache-Control = %q, want no-store", got)
+	}
+	token := extractInjectedToken(t, string(body))
+
+	replayResp, err := http.Get(baseURL + "/?token=" + bootstrapToken)
+	if err != nil {
+		t.Fatalf("replay bootstrap token: %v", err)
+	}
+	replayResp.Body.Close()
+	if replayResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("replayed bootstrap status = %d, want %d", replayResp.StatusCode, http.StatusForbidden)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/heartbeat?token="+token, nil)
@@ -444,6 +461,9 @@ func TestStartServerLifecycleRootAndHeartbeat(t *testing.T) {
 	if heartbeatResp.StatusCode != http.StatusOK {
 		t.Fatalf("heartbeat status = %d, want %d", heartbeatResp.StatusCode, http.StatusOK)
 	}
+	if heartbeatResp.Header.Get("X-BeamSync-Token") == "" {
+		t.Fatal("heartbeat did not return a renewed session token")
+	}
 	if got := heartbeatResp.Header.Get("Access-Control-Allow-Origin"); got != "" {
 		t.Fatalf("heartbeat Access-Control-Allow-Origin = %q, want empty", got)
 	}
@@ -453,6 +473,71 @@ func TestStartServerLifecycleRootAndHeartbeat(t *testing.T) {
 	}
 	if err := server.Shutdown(); err != nil {
 		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+func TestStartSenderIssuesClientBoundSingleUseDownloadToken(t *testing.T) {
+	t.Setenv(tlsEnvVar, "")
+	filePath := filepath.Join(t.TempDir(), "secure.txt")
+	if err := os.WriteFile(filePath, []byte("secure payload"), 0600); err != nil {
+		t.Fatalf("write sender fixture: %v", err)
+	}
+
+	server, port, bootstrapToken := StartSender([]string{filePath}, nil)
+	if server == nil {
+		t.Fatal("StartSender returned nil server")
+	}
+	defer server.Shutdown()
+	baseURL := "http://127.0.0.1:" + port
+
+	rootResp, err := http.Get(baseURL + "/?token=" + bootstrapToken)
+	if err != nil {
+		t.Fatalf("GET sender page: %v", err)
+	}
+	rootBody, err := io.ReadAll(rootResp.Body)
+	rootResp.Body.Close()
+	if err != nil || rootResp.StatusCode != http.StatusOK {
+		t.Fatalf("sender page status=%d err=%v", rootResp.StatusCode, err)
+	}
+
+	replayRootResp, err := http.Get(baseURL + "/?token=" + bootstrapToken)
+	if err != nil {
+		t.Fatalf("replay sender bootstrap: %v", err)
+	}
+	replayRootResp.Body.Close()
+	if replayRootResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("replayed sender bootstrap status=%d, want %d", replayRootResp.StatusCode, http.StatusForbidden)
+	}
+
+	const linkPrefix = "/download?token="
+	start := strings.Index(string(rootBody), linkPrefix)
+	if start == -1 {
+		t.Fatal("sender page did not include a secure download link")
+	}
+	start += len(linkPrefix)
+	end := strings.IndexAny(string(rootBody[start:]), "'\"")
+	if end == -1 {
+		t.Fatal("secure download token was not terminated")
+	}
+	downloadURL := baseURL + linkPrefix + string(rootBody[start:start+end])
+
+	firstResp, err := http.Get(downloadURL)
+	if err != nil {
+		t.Fatalf("first secure download: %v", err)
+	}
+	firstBody, _ := io.ReadAll(firstResp.Body)
+	firstResp.Body.Close()
+	if firstResp.StatusCode != http.StatusOK || string(firstBody) != "secure payload" {
+		t.Fatalf("first download status=%d body=%q", firstResp.StatusCode, firstBody)
+	}
+
+	replayResp, err := http.Get(downloadURL)
+	if err != nil {
+		t.Fatalf("replayed secure download: %v", err)
+	}
+	replayResp.Body.Close()
+	if replayResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("replayed download status=%d, want %d", replayResp.StatusCode, http.StatusForbidden)
 	}
 }
 
@@ -708,6 +793,23 @@ func waitForEvent(events <-chan string, want string, timeout time.Duration) bool
 
 func startServerForTest(t *testing.T) (*HTTPServer, string, string, <-chan string, string) {
 	t.Helper()
+	server, baseURL, bootstrapToken, events, uploadDir := startRawServerForTest(t)
+	resp, err := http.Get(baseURL + "/?token=" + bootstrapToken)
+	if err != nil {
+		server.Shutdown()
+		t.Fatalf("exchange bootstrap token: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil || resp.StatusCode != http.StatusOK {
+		server.Shutdown()
+		t.Fatalf("bootstrap exchange status=%d err=%v body=%q", resp.StatusCode, err, body)
+	}
+	return server, baseURL, extractInjectedToken(t, string(body)), events, uploadDir
+}
+
+func startRawServerForTest(t *testing.T) (*HTTPServer, string, string, <-chan string, string) {
+	t.Helper()
 	uploadDir := t.TempDir()
 	startPort := freePort(t)
 	events := make(chan string, 20)
@@ -724,6 +826,21 @@ func startServerForTest(t *testing.T) (*HTTPServer, string, string, <-chan strin
 		t.Fatalf("StartServer port = %q, want %d", port, startPort)
 	}
 	return server, "http://127.0.0.1:" + port, token, events, uploadDir
+}
+
+func extractInjectedToken(t *testing.T, html string) string {
+	t.Helper()
+	const prefix = `let TOKEN = "`
+	start := strings.Index(html, prefix)
+	if start == -1 {
+		t.Fatal("page did not include an injected session token")
+	}
+	start += len(prefix)
+	end := strings.Index(html[start:], `"`)
+	if end == -1 {
+		t.Fatal("injected session token was not terminated")
+	}
+	return html[start : start+end]
 }
 
 func multipartUploadBody(t *testing.T, filename string, payload []byte) (bytes.Buffer, string) {

--- a/beamsync/tls.go
+++ b/beamsync/tls.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -37,6 +38,22 @@ func ServerScheme() string {
 		return "https"
 	}
 	return "http"
+}
+
+func serverTLSFingerprint() (string, error) {
+	if !TLSEnabled() {
+		return "plaintext-http", nil
+	}
+
+	cert, err := loadOrCreateLocalCertificate(localCertificateHosts())
+	if err != nil {
+		return "", err
+	}
+	if len(cert.Certificate) == 0 {
+		return "", fmt.Errorf("TLS certificate has no DER data")
+	}
+	fingerprint := sha256.Sum256(cert.Certificate[0])
+	return fmt.Sprintf("%x", fingerprint[:]), nil
 }
 
 func maybeTLSListener(listener net.Listener) (net.Listener, bool, error) {

--- a/beamsync/ui/download.html
+++ b/beamsync/ui/download.html
@@ -376,7 +376,7 @@
     </div>
 
     <script>
-        const TOKEN = "{{TOKEN}}";
+        let TOKEN = "{{TOKEN}}";
 
         // ── Progress tracking ──────────────────────────────────────
         let progressState = {
@@ -556,7 +556,11 @@
                     if (btn) { btn.classList.remove('downloading'); btn.textContent = 'RETRY'; }
                     if (chip) chip.className = 'file-card__chip';
                     document.getElementById('active-progress').classList.remove('visible');
-                    alert('Download failed — please try again.');
+                    if (xhr.status === 401 || xhr.status === 403) {
+                        alert('This secure download link expired or was already used. Re-scan the current QR code to reconnect.');
+                    } else {
+                        alert('Download failed — please try again.');
+                    }
                 }
             });
 
@@ -579,9 +583,11 @@
             const url = TOKEN ? `/heartbeat?token=${TOKEN}` : '/heartbeat';
             fetch(url, { method: 'POST' })
                 .then(r => {
+                    const renewedToken = r.headers.get('X-BeamSync-Token');
+                    if (renewedToken) TOKEN = renewedToken;
                     if (r.status === 401 || r.status === 403) {
                         _reloading = true;
-                        setTimeout(() => location.reload(), 800);
+                        alert('Your BeamSync session expired. Re-scan the current QR code to reconnect.');
                     }
                 })
                 .catch(() => {});

--- a/beamsync/ui/upload.html
+++ b/beamsync/ui/upload.html
@@ -423,7 +423,7 @@
     </div>
 
     <script>
-        const TOKEN = "{{TOKEN}}";
+        let TOKEN = "{{TOKEN}}";
 
         // ── File state ──────────────────────────────────────────────
         // fileStates[i] = { name, size, status: 'queued'|'uploading'|'done'|'error' }
@@ -443,10 +443,11 @@
             if (_reloading) return;
             fetch("/heartbeat?token=" + TOKEN, { method: "POST" })
                 .then(r => {
+                    const renewedToken = r.headers.get('X-BeamSync-Token');
+                    if (renewedToken) TOKEN = renewedToken;
                     if ((r.status === 401 || r.status === 403) && !_uploading) {
                         _reloading = true;
-                        setStatus('Connection changed — reconnecting…', false);
-                        setTimeout(() => location.reload(), 800);
+                        setStatus('Session expired — re-scan the current QR code to reconnect', false);
                     }
                 })
                 .catch(() => {});

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -377,8 +377,7 @@ func (a *App) StartSender() string {
 	a.currentIP = localIP
 	a.currentPort = port
 
-	// Root page loads without token (acts as the landing), downloads require token.
-	url := fmt.Sprintf("%s://%s:%s/", beamsync.ServerScheme(), localIP, port)
+	url := fmt.Sprintf("%s://%s:%s/?token=%s", beamsync.ServerScheme(), localIP, port, token)
 
 	fmt.Println("========================================")
 	fmt.Println("📤 SENDER STARTED:", url)
@@ -431,7 +430,7 @@ func (a *App) SendFiles(filePaths []string) string {
 	a.currentIP = localIP
 	a.currentPort = port
 
-	url := fmt.Sprintf("%s://%s:%s/", beamsync.ServerScheme(), localIP, port)
+	url := fmt.Sprintf("%s://%s:%s/?token=%s", beamsync.ServerScheme(), localIP, port, token)
 
 	fmt.Println("========================================")
 	fmt.Println("📤 SENDER STARTED (from drag-drop):", url)


### PR DESCRIPTION
## Description

Replaces BeamSync's reusable shared session token with short-lived HMAC-signed credentials:

- single-use QR bootstrap tokens for receiver and sender landing pages
- five-minute session tokens bound to the client IP and server TLS fingerprint
- heartbeat-driven session renewal with `Cache-Control: no-store`
- single-use, client-bound download URLs that reject replay attempts
- expiry cleanup plus clear reconnect guidance in both web clients

## Related Issue(s)

Fixes #63

## Motivation and Context

The previous token was embedded in the page and remained reusable for the server lifetime. A copied URL could therefore be replayed from another client. This change gives each server a random HMAC secret and session ID, signs scoped credentials over their TLS context, client binding, expiry, and nonce, and atomically consumes one-use credentials.

## How Has This Been Tested?

- [x] Unit tests added for expiry, scope and client binding, tampering, and replay prevention
- [x] Integration tests added for bootstrap exchange, heartbeat renewal, and single-use downloads
- [x] Manual testing steps performed:
  - Built the Wails frontend with `npm.cmd ci` and `npm.cmd run build`
  - Ran core Go tests, desktop Go tests, `go vet`, and `git diff --check`

Validation commands:

```text
cd beamsync
go test -skip '^TestLoadOrCreateLocalCertificatePersistsSecureECDSAFiles$' -count=1 ./...
go vet ./...

cd ../desktop/frontend
npm.cmd ci
npm.cmd run build

cd ..
go test ./...
go vet ./...
```

The full Windows core run has one pre-existing platform-specific failure in `TestLoadOrCreateLocalCertificatePersistsSecureECDSAFiles`: the test overrides `HOME`, while Windows `os.UserHomeDir()` continues resolving the profile directory. All other core tests pass.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Refactoring / code cleanup
- [ ] Performance improvement

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally except for the documented pre-existing Windows-only TLS path test
- [x] I have updated the relevant documentation

## Screenshots (if applicable)

Not applicable; the visible UI change is limited to clearer expired-session and replay guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented short-lived, HMAC-signed, QR bootstrap → session credential flow with TLS/client binding and scoped access.
  * Added heartbeat-based token rotation (`X-BeamSync-Token`) to keep transfers active.
  * Introduced single-use, client-bound download tokens that reject replay attempts.
  * Updated sender start URLs to include the required token parameter.
* **Documentation**
  * Updated `API.md` examples and parameter text to match the new auth/renewal behavior and caching rules.
  * Expanded `README` Security & Privacy notes with ephemeral credentials details.
* **Bug Fixes**
  * Improved upload/download UI handling of refreshed tokens and 401/403 behavior (prompt re-scan instead of reload).
* **Tests**
  * Added/updated unit and server tests to verify expiration, max-use, tampering rejection, and replay denial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->