### PR TITLE
Test edge case failure modes

### DIFF
--- a/beamsync/history_test.go
+++ b/beamsync/history_test.go
@@ -131,7 +131,6 @@ func TestTransferHistoryEmptyState(t *testing.T) {
 
 func TestTransferHistoryNilReceiver(t *testing.T) {
 	var history *TransferHistory
-	// Should not panic
 	record := history.Add(TransferRecord{Filename: "test.txt"})
 	if record.Filename != "test.txt" {
 		t.Fatalf("expected returned record to match input, got %v", record)

--- a/beamsync/history_test.go
+++ b/beamsync/history_test.go
@@ -81,6 +81,136 @@ func TestTransferHistoryFillsTimingMetadata(t *testing.T) {
 	}
 }
 
+func TestTransferHistoryExactCapacity(t *testing.T) {
+	history := NewTransferHistory(3)
+	for i := 1; i <= 3; i++ {
+		history.Add(TransferRecord{Filename: fmt.Sprintf("file-%d.txt", i)})
+	}
+	records := history.List()
+	if len(records) != 3 {
+		t.Fatalf("expected length 3, got %d", len(records))
+	}
+}
+
+func TestTransferHistoryWrapAround(t *testing.T) {
+	history := NewTransferHistory(3)
+	for i := 1; i <= 4; i++ {
+		history.Add(TransferRecord{Filename: fmt.Sprintf("file-%d.txt", i)})
+	}
+	records := history.List()
+	if len(records) != 3 {
+		t.Fatalf("expected length 3, got %d", len(records))
+	}
+	if records[0].Filename != "file-4.txt" || records[1].Filename != "file-3.txt" || records[2].Filename != "file-2.txt" {
+		t.Fatalf("unexpected wrap-around behavior: %v", records)
+	}
+}
+
+func TestTransferHistorySingleEntry(t *testing.T) {
+	history := NewTransferHistory(3)
+	history.Add(TransferRecord{Filename: "single.txt"})
+	records := history.List()
+	if len(records) != 1 {
+		t.Fatalf("expected length 1, got %d", len(records))
+	}
+	if records[0].Filename != "single.txt" {
+		t.Fatalf("expected single.txt, got %s", records[0].Filename)
+	}
+}
+
+func TestTransferHistoryEmptyState(t *testing.T) {
+	history := NewTransferHistory(3)
+	records := history.List()
+	if records == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
+	if len(records) != 0 {
+		t.Fatalf("expected length 0, got %d", len(records))
+	}
+}
+
+func TestTransferHistoryNilReceiver(t *testing.T) {
+	var history *TransferHistory
+	// Should not panic
+	record := history.Add(TransferRecord{Filename: "test.txt"})
+	if record.Filename != "test.txt" {
+		t.Fatalf("expected returned record to match input, got %v", record)
+	}
+	records := history.List()
+	if records != nil {
+		t.Fatalf("expected nil from nil receiver List(), got %v", records)
+	}
+}
+
+func TestTransferHistoryCustomMaxEntries(t *testing.T) {
+	history := NewTransferHistory(1)
+	history.Add(TransferRecord{Filename: "1.txt"})
+	history.Add(TransferRecord{Filename: "2.txt"})
+	history.Add(TransferRecord{Filename: "3.txt"})
+	records := history.List()
+	if len(records) != 1 {
+		t.Fatalf("expected length 1, got %d", len(records))
+	}
+	if records[0].Filename != "3.txt" {
+		t.Fatalf("expected 3.txt, got %v", records[0].Filename)
+	}
+}
+
+func TestTransferHistoryZeroMaxEntries(t *testing.T) {
+	history := NewTransferHistory(0)
+	for i := 0; i < defaultTransferHistoryLimit+5; i++ {
+		history.Add(TransferRecord{Filename: "test.txt"})
+	}
+	records := history.List()
+	if len(records) != defaultTransferHistoryLimit {
+		t.Fatalf("expected default limit %d, got %d", defaultTransferHistoryLimit, len(records))
+	}
+}
+
+func TestTransferHistoryConcurrentAccess(t *testing.T) {
+	history := NewTransferHistory(100)
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			history.Add(TransferRecord{Filename: "concurrent.txt"})
+		}
+		close(done)
+	}()
+
+	for {
+		select {
+		case <-done:
+			return
+		default:
+			history.List()
+		}
+	}
+}
+
+func TestTransferHistoryRecordIDGeneration(t *testing.T) {
+	history := NewTransferHistory(10)
+	rec1 := history.Add(TransferRecord{})
+	if rec1.ID == "" {
+		t.Fatal("expected auto-generated ID")
+	}
+
+	rec2 := history.Add(TransferRecord{ID: "custom-id"})
+	if rec2.ID != "custom-id" {
+		t.Fatalf("expected preserved custom-id, got %v", rec2.ID)
+	}
+}
+
+func TestTransferHistoryTimestampFallback(t *testing.T) {
+	history := NewTransferHistory(10)
+	rec := history.Add(TransferRecord{Filename: "test.txt"})
+	if rec.StartedAt.IsZero() {
+		t.Fatal("expected StartedAt to be populated")
+	}
+	if rec.StartedAt != rec.CompletedAt {
+		t.Fatalf("expected StartedAt == CompletedAt, got StartedAt=%v, CompletedAt=%v", rec.StartedAt, rec.CompletedAt)
+	}
+}
+
 func BenchmarkTransferHistoryAddAtCapacity(b *testing.B) {
 	history := NewTransferHistory(100)
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION


## Description
This PR improves the test coverage of the `TransferHistory` ring buffer in `history.go`. It implements 10 new test cases to cover missing edge cases and failure modes. 

## Related Issue(s)
Fixes #88 

## Motivation and Context
The `TransferHistory` ring buffer had good coverage for the happy path but zero coverage for edge cases. By adding these tests, we ensure the history tracker safely handles initialization states, capacity limits, wrap-arounds, nil pointers, and concurrent access. 

## How Has This Been Tested?
- [x] Unit tests added (if applicable)
- [ ] Integration tests added (if applicable)
- [x] Manual testing steps performed:
  - Ran `go test -v ./beamsync` to verify the newly added history tests pass successfully. 
  - Verified concurrency safety of `TransferHistory` via `go test -race`.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Performance improvement
- [x] Test Case Additions

## Checklist
- [x] My code follows the project’s style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated the relevant documentation (if any)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for transfer history behavior, including capacity limits, ordering when entries wrap, empty and single-item states, and custom size settings.
  * Added checks for concurrent access, record ID handling, and timestamp fallback behavior.
  * Improved validation of edge cases to help ensure more reliable history tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->