### PR TITLE
fix: filter TLS certificate SAN hosts

### DIFF
--- a/beamsync/tls.go
+++ b/beamsync/tls.go
@@ -197,7 +197,7 @@ func localCertificateHosts() []string {
 		if iface.Flags&net.FlagUp == 0 {
 			continue
 		}
-		if shouldSkipCertificateInterface(iface.Name) {
+		if iface.Flags&net.FlagLoopback != 0 || shouldSkipCertificateInterface(iface.Name) {
 			continue
 		}
 		addrs, err := iface.Addrs()

--- a/beamsync/tls.go
+++ b/beamsync/tls.go
@@ -197,6 +197,9 @@ func localCertificateHosts() []string {
 		if iface.Flags&net.FlagUp == 0 {
 			continue
 		}
+		if shouldSkipCertificateInterface(iface.Name) {
+			continue
+		}
 		addrs, err := iface.Addrs()
 		if err != nil {
 			continue
@@ -209,13 +212,45 @@ func localCertificateHosts() []string {
 			case *net.IPAddr:
 				ip = v.IP
 			}
-			if ip == nil || ip.IsUnspecified() {
+			if ip == nil || ip.IsUnspecified() || !isRelevantCertificateIP(ip) {
 				continue
 			}
 			hosts = append(hosts, ip.String())
 		}
 	}
 	return dedupeStrings(hosts)
+}
+
+func shouldSkipCertificateInterface(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return false
+	}
+	virtualPrefixes := []string{"docker", "br-", "veth", "tun", "tap", "wg", "vmnet", "vboxnet"}
+	for _, prefix := range virtualPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	virtualFragments := []string{"virtual", "hyper-v", "tailscale", "zerotier"}
+	for _, fragment := range virtualFragments {
+		if strings.Contains(name, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRelevantCertificateIP(ip net.IP) bool {
+	if ip.IsLoopback() {
+		return true
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		return ip4[0] == 10 ||
+			(ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31) ||
+			(ip4[0] == 192 && ip4[1] == 168)
+	}
+	return ip.IsLinkLocalUnicast()
 }
 
 func dedupeStrings(values []string) []string {

--- a/beamsync/tls_test.go
+++ b/beamsync/tls_test.go
@@ -147,6 +147,50 @@ func TestMaybeTLSListenerWrapsOnlyWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestCertificateHostFilteringKeepsOnlyRelevantLANIPs(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{name: "loopback ipv4", ip: "127.0.0.1", want: true},
+		{name: "private class a", ip: "10.2.3.4", want: true},
+		{name: "private class b", ip: "172.20.1.9", want: true},
+		{name: "private class c", ip: "192.168.1.20", want: true},
+		{name: "link local ipv6", ip: "fe80::1", want: true},
+		{name: "public ipv4", ip: "8.8.8.8", want: false},
+		{name: "carrier nat", ip: "100.64.0.1", want: false},
+		{name: "public ipv6", ip: "2001:4860:4860::8888", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isRelevantCertificateIP(net.ParseIP(tc.ip))
+			if got != tc.want {
+				t.Fatalf("isRelevantCertificateIP(%s) = %v, want %v", tc.ip, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCertificateHostFilteringSkipsVirtualInterfaces(t *testing.T) {
+	for _, name := range []string{"docker0", "br-1234", "vethabc", "tun0", "tap1", "wg0", "vboxnet0", "Hyper-V Adapter", "tailscale0"} {
+		t.Run(name, func(t *testing.T) {
+			if !shouldSkipCertificateInterface(name) {
+				t.Fatalf("shouldSkipCertificateInterface(%q) = false, want true", name)
+			}
+		})
+	}
+
+	for _, name := range []string{"eth0", "en0", "wlan0", "Wi-Fi"} {
+		t.Run(name, func(t *testing.T) {
+			if shouldSkipCertificateInterface(name) {
+				t.Fatalf("shouldSkipCertificateInterface(%q) = true, want false", name)
+			}
+		})
+	}
+}
+
 func assertFileMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- skip virtual/tunnel interfaces when collecting self-signed certificate SAN hosts
- only include loopback, RFC1918 IPv4, and link-local IPv6 addresses
- add unit coverage for IP and interface filtering helpers

Fixes #89

## Validation
- Not run locally: Go toolchain is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local TLS certificate host selection by skipping likely virtual/tunnel interfaces.
  * Tightened local IP filtering to include only relevant addresses (e.g., loopback, selected private LAN ranges, and link-local unicast) while excluding public and non-local candidates.
* **Tests**
  * Added test coverage to ensure only relevant LAN IPs are retained for certificate subjectAltNames.
  * Added test coverage to verify virtual/tunnel interface names are skipped while common physical interface names are kept.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->