### PR TITLE
security: restrict server binding to loopback by default (closes #101)

### DIFF
--- a/beamsync/port_manager.go
+++ b/beamsync/port_manager.go
@@ -3,19 +3,26 @@ package beamsync
 import (
 	"fmt"
 	"net"
+	"os"
 	"strings"
 )
 
 // FindAvailablePort tries to find a free port starting from startPort.
 // It iterates by 'step' (e.g. 2 for even/odd only) up to maxAttempts.
 // It returns the allocated port, the active listener, and any error.
+// By default, binds to 127.0.0.1 (loopback) only. Set BEAMSYNC_LAN_MODE=true to bind to all interfaces.
 func FindAvailablePort(startPort int, step int, maxAttempts int) (int, net.Listener, error) {
+	bindHost := "127.0.0.1"
+	if os.Getenv("BEAMSYNC_LAN_MODE") == "true" {
+		bindHost = "0.0.0.0"
+	}
+
 	for i := 0; i < maxAttempts; i++ {
 		port := startPort + (i * step)
-		addr := fmt.Sprintf(":%d", port)
+		addr := fmt.Sprintf("%s:%d", bindHost, port)
 		listener, err := net.Listen("tcp", addr)
 		if err == nil {
-			fmt.Printf("🎯 Found available port: %d\n", port)
+			fmt.Printf("🎯 Found available port: %d (bind: %s)\n", port, bindHost)
 			return port, listener, nil
 		}
 


### PR DESCRIPTION
## Summary

Prevent LAN peers from intercepting BeamSync file transfers by binding to localhost only.

## Problem

Server was binding to 0.0.0.0 (all interfaces) instead of 127.0.0.1 (localhost). On any shared network (WiFi, office LAN, campus network), any peer could:
- Scan for open ports: `nmap -p 3000-3098 <sender_ip>`
- Connect and download files: `curl http://<sender_ip>:<port>/file`
- Bypass all access controls (no authentication required for file endpoint)

## Root Cause

In port_manager.go, FindAvailablePort() used `fmt.Sprintf(":%d", port)` which binds to 0.0.0.0.

## Solution

- Default binding: 127.0.0.1 (localhost only)
- Optional LAN mode: Set BEAMSYNC_LAN_MODE=true to bind to 0.0.0.0
- Log binding host for visibility

Before:
```
addr := fmt.Sprintf(":%d", port)  // Binds to 0.0.0.0:port
```

After:
```
bindHost := "127.0.0.1"
if os.Getenv("BEAMSYNC_LAN_MODE") == "true" {
    bindHost = "0.0.0.0"
}
addr := fmt.Sprintf("%s:%d", bindHost, port)
```

## Impact

- Transfers only accessible via localhost (secure default)
- LAN peers cannot discover or intercept transfers
- Preserves ability to enable LAN mode for enterprise/lab environments
- Confidential data protection on shared networks

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Networking**
  * Available ports now bind to the local device by default, reducing unintended network exposure.
  * Added an optional LAN mode that allows binding across network interfaces when explicitly enabled.
  * Port-binding messages now indicate the address being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->