### PR TITLE
fix: initialize entries slice in NewTransferHistory

### DIFF
--- a/beamsync/history.go
+++ b/beamsync/history.go
@@ -43,7 +43,10 @@ func NewTransferHistory(maxEntries int) *TransferHistory {
 	if maxEntries <= 0 {
 		maxEntries = defaultTransferHistoryLimit
 	}
-	return &TransferHistory{maxEntries: maxEntries}
+	return &TransferHistory{
+		maxEntries: maxEntries,
+		entries:    make([]TransferRecord, maxEntries),
+	}
 }
 
 func (h *TransferHistory) Add(record TransferRecord) TransferRecord {


### PR DESCRIPTION
NewTransferHistory did not initialize the entries slice, leaving it nil. While the Add function handled nil entries lazily, initializing in the constructor is safer and follows Go best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer history initialization to ensure history entries are available immediately and behave consistently when adding or listing transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->