### PR TITLE
docs: add port troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The following network types may block or limit BeamSync functionality:
 
 - Firewalls on Linux, Windows, or macOS may block incoming connections
 - BeamSync uses TCP ports **3000–3098** for local transfers. Ensure these ports are allowed through your firewall when necessary.
+- If a transfer fails because the selected port is unavailable or blocked, check the firewall rules for the BeamSync port range before troubleshooting the network connection further.
 - On Linux, BeamSync can automatically configure firewall rules when required through its built-in firewall setup mechanism (`ufw`, `firewalld`, or `iptables`).
 - Ensure BeamSync is allowed through your system firewall if prompted
 


### PR DESCRIPTION
## Description
Added a troubleshooting note to the network requirements section explaining what to check when a BeamSync transfer fails because the selected port is unavailable or blocked.

## Related Issue(s)
Closes #None (just a documentation quick fix)

## Motivation and Context
This clarifies the troubleshooting process for port-related transfer failures and helps contributors/users check firewall rules for the BeamSync port range before investigating other network issues.

## How Has This Been Tested?
- [ ] Unit tests added (if applicable)
- [ ] Integration tests added (if applicable)
- [x] Manual testing steps performed:
  - Reviewed the updated README documentation.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Performance improvement

## Checklist
- [x] My code follows the project’s style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [x] I have updated the relevant documentation (if any)

## Screenshots (if applicable)
Not applicable — documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for firewall and router configurations when a selected BeamSync port is unavailable or blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->