### PR TITLE
docs: clarify TLS certificate path is OS-specific, not Linux-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ For developers, contributors, and security auditors who want to understand the u
 ## Security & Privacy
 
 - **Local-only** — All transfers happen over your LAN. No external servers are contacted.
-- **Optional HTTPS** — Set `BEAMSYNC_ENABLE_TLS=true` before launching BeamSync to serve receiver and sender pages over HTTPS with a persisted ECDSA local certificate in `~/.config/beamsync/`.
+- **Optional HTTPS** — Set `BEAMSYNC_ENABLE_TLS=true` before launching BeamSync to serve receiver and sender pages over HTTPS with a persisted ECDSA local certificate stored in your OS's standard config directory for BeamSync (e.g. `~/.config/beamsync/` on Linux, `~/Library/Application Support/beamsync/` on macOS, `%AppData%\beamsync\` on Windows).
 - **Ephemeral credentials** — HMAC-signed sessions expire after five minutes, bind to the connecting client and TLS context, renew through heartbeats, and use single-use links for downloads.
 - **Zero data collection** — BeamSync does not store, transmit, or analyze your files beyond the direct LAN transfer.
 - **Open source** — The entire codebase is available for audit.


### PR DESCRIPTION
# Pull Request Template

## Description
Clarified the TLS certificate storage path in README.md's Security & Privacy section. It listed only the Linux-specific `~/.config/beamsync/` path as if it applied universally, even though BeamSync is cross-platform (Wails app supporting macOS and Windows). Updated it to note the correct OS-specific paths for each platform.

## Related Issue(s)
None (just a documentation quick fix)

## Motivation and Context
Presenting the Linux-only config path as universal could mislead macOS or Windows users trying to locate their local TLS certificate, since Wails/Go apps typically use OS-specific config directories (`~/Library/Application Support/` on macOS, `%AppData%` on Windows).

## How Has This Been Tested?
- [ ] Unit tests added (if applicable)
- [ ] Integration tests added (if applicable)
- [x] Manual testing steps performed:
  - Verified the documented paths match standard OS config directory conventions used by Go/Wails apps

## Types of Changes
- [x] Documentation update

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [x] I have updated the relevant documentation (if any)

## Screenshots (if applicable)
N/A — documentation-only fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified where persisted ECDSA certificates are stored for optional HTTPS.
  * Added platform-specific examples covering the operating system’s standard BeamSync configuration directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->